### PR TITLE
feat: 添加 -F/--list-formats 列出所有可用音质格式

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ xdl album <专辑链接或 albumId>
 ```bash
 xdl login                              # 首次登录或重新登录
 xdl track <链接或ID>                    # 下载单个音频
+xdl track -F <链接或ID>                 # 列出所有可用音质格式，不下载
 xdl album <链接或ID>                    # 下载整张专辑
 xdl album <链接或ID> --range 1-20       # 只下载指定区间
 xdl album <链接或ID> --quality high     # high / standard / low
@@ -64,6 +65,7 @@ xdl --concurrency 3 resume
 
 ### 下载行为
 
+- `xdl track -F <链接或ID>` 会按码率和编码优先级列出可用格式，只读取播放元数据，不下载音频。
 - 音质缺失时会自动回退到可用规格。
 - 已存在的完整文件会跳过。
 - 未完成的 `.part` 文件支持 HTTP Range 续传。

--- a/src/xdl/application/facade.py
+++ b/src/xdl/application/facade.py
@@ -12,7 +12,7 @@ import signal
 import threading
 from collections.abc import Callable
 
-from ..domain import Quality, parse_range
+from ..domain import Quality, parse_range, parse_track_id
 from ..errors import XdlError
 from ..settings import Settings
 from .usecases import (DownloadTrackUseCase, DownloadAlbumUseCase, AlbumResult,
@@ -72,9 +72,8 @@ class Facade:
     def list_formats(self, target: str) -> dict:
         """列出某个曲目所有可用音质格式（类似 yt-dlp -F）。
 
-        返回 {'title': str, 'track_id': str, 'formats': [{type, file_size}],
-               'default_quality': str}
-        URL 不解密——本方法只用于展示格式清单，不发下载请求。
+        返回曲目信息及已排序的格式元数据。本方法不发起音频下载请求，
+        也不向调用方返回播放 URL。
         """
         return asyncio.run(self._list_formats(target))
 
@@ -152,17 +151,21 @@ class Facade:
             cleanup_signal()
 
     async def _list_formats(self, target: str) -> dict:
-        from ..domain import parse_track_id
         track_id = parse_track_id(target)
         await self._source.open()
         try:
             track = await self._source.get_track(track_id)
         finally:
             await self._source.close()
-        formats = []
-        for p in track.play_urls:
-            if p.url:
-                formats.append({"type": p.type, "file_size": p.file_size})
+        formats = [
+            {
+                "type": p.type,
+                "codec": p.codec,
+                "bitrate": p.bitrate,
+                "file_size": p.file_size,
+            }
+            for p in track.available_play_urls()
+        ]
         return {
             "title": track.title,
             "track_id": track.track_id,

--- a/src/xdl/application/facade.py
+++ b/src/xdl/application/facade.py
@@ -69,6 +69,15 @@ class Facade:
         store = self._task_store()
         return store.all_tasks() if store is not None else []
 
+    def list_formats(self, target: str) -> dict:
+        """列出某个曲目所有可用音质格式（类似 yt-dlp -F）。
+
+        返回 {'title': str, 'track_id': str, 'formats': [{type, file_size}],
+               'default_quality': str}
+        URL 不解密——本方法只用于展示格式清单，不发下载请求。
+        """
+        return asyncio.run(self._list_formats(target))
+
     def inspect_storage(self) -> dict:
         """诊断：列出当前 Profile 的设备标识存储 key 名（不读 value），
         验证"清 Cookie"覆盖面是否完整。只读、不下载、不重置设备指纹。"""
@@ -141,6 +150,25 @@ class Facade:
         finally:
             self._cancel_task(watcher)
             cleanup_signal()
+
+    async def _list_formats(self, target: str) -> dict:
+        from ..domain import parse_track_id
+        track_id = parse_track_id(target)
+        await self._source.open()
+        try:
+            track = await self._source.get_track(track_id)
+        finally:
+            await self._source.close()
+        formats = []
+        for p in track.play_urls:
+            if p.url:
+                formats.append({"type": p.type, "file_size": p.file_size})
+        return {
+            "title": track.title,
+            "track_id": track.track_id,
+            "formats": formats,
+            "default_quality": self._settings.default_quality,
+        }
 
     def _watch_external_cancel(self, cancel: threading.Event | None,
                                stop_event: asyncio.Event,

--- a/src/xdl/domain/models.py
+++ b/src/xdl/domain/models.py
@@ -59,6 +59,17 @@ class PlayUrl:
     file_size: int = 0
 
     @property
+    def codec(self) -> str:
+        """返回音质类型中的编码名称；未知格式保留平台给出的名称。"""
+        head = (self.type or "").split("_", 1)[0]
+        return head.upper() if head else "?"
+
+    @property
+    def bitrate(self) -> int:
+        """返回音质类型中的码率；无法识别时返回 0。"""
+        return _type_score(self.type)[0]
+
+    @property
     def is_m4a(self) -> bool:
         return self.type.startswith("M4A") or ".m4a" in self.url.lower()
 
@@ -95,6 +106,14 @@ class Track:
     play_urls: list[PlayUrl] = field(default_factory=list)
     is_paid: bool = False
     is_authorized: bool = True
+
+    def available_play_urls(self) -> list[PlayUrl]:
+        """返回带有效地址的资源，并按音质协商规则从高到低排序。"""
+        return sorted(
+            (p for p in self.play_urls if p.url),
+            key=lambda p: _type_score(p.type),
+            reverse=True,
+        )
 
     def select(self, quality: Quality) -> PlayUrl | None:
         """按音质协商选出一个可用的 PlayUrl。"""

--- a/src/xdl/frontends/cli.py
+++ b/src/xdl/frontends/cli.py
@@ -54,10 +54,46 @@ def _cmd_login(app: Facade, args) -> int:
 
 
 def _cmd_track(app: Facade, args) -> int:
+    if args.list_formats:
+        return _cmd_list_formats(app, args)
     path = app.download_track(args.target, quality=args.quality,
                               reporter=ConsoleProgress())
     print(f"已保存: {path}")
     return 0
+
+
+def _cmd_list_formats(app: Facade, args) -> int:
+    info = app.list_formats(args.target)
+    # 按码率+编码排序，与 Quality.negotiate 一致
+    from ..domain.models import _type_score
+    formats = sorted(info["formats"], key=lambda f: _type_score(f["type"]),
+                     reverse=True)
+
+    print(f"曲目: {info['title']}")
+    print(f"ID: {info['track_id']}")
+    print(f"默认音质: {info['default_quality']}")
+    print()
+    print(f"{'ID':>3s}  {'格式':12s} {'编码':>5s}  {'码率':>6s}  {'文件大小':>10s}")
+    print(f"{'---':3s}  {'----------':12s} {'-----':>5s}  {'------':>6s}  {'----------':>10s}")
+    for i, f in enumerate(formats):
+        parts = f["type"].split("_")
+        codec = parts[0] if parts else "?"
+        bitrate = parts[1] if len(parts) >= 2 else "?"
+        size_str = _fmt_size(f["file_size"])
+        print(f"{i:3d}  {f['type']:12s} {codec:>5s}  {bitrate + 'k':>6s}  {size_str:>10s}")
+    print()
+    print(f"共 {len(formats)} 种格式")
+    return 0
+
+
+def _fmt_size(size_bytes: int) -> str:
+    if size_bytes <= 0:
+        return "未知"
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes / (1024 * 1024):.1f} MB"
 
 
 def _cmd_album(app: Facade, args) -> int:
@@ -191,6 +227,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_track.add_argument("target", help="音频链接或 trackId")
     p_track.add_argument("--quality", choices=["high", "standard", "low"],
                          help="音质（默认 standard，缺失时自动回退）")
+    p_track.add_argument("-F", "--list-formats", action="store_true",
+                         help="列出所有可用音质格式（类似 yt-dlp -F）")
 
     p_album = sub.add_parser("album", help="顺序批量下载整张专辑")
     p_album.add_argument("target", help="专辑链接或 albumId")

--- a/src/xdl/frontends/cli.py
+++ b/src/xdl/frontends/cli.py
@@ -64,10 +64,7 @@ def _cmd_track(app: Facade, args) -> int:
 
 def _cmd_list_formats(app: Facade, args) -> int:
     info = app.list_formats(args.target)
-    # 按码率+编码排序，与 Quality.negotiate 一致
-    from ..domain.models import _type_score
-    formats = sorted(info["formats"], key=lambda f: _type_score(f["type"]),
-                     reverse=True)
+    formats = info["formats"]
 
     print(f"曲目: {info['title']}")
     print(f"ID: {info['track_id']}")
@@ -76,11 +73,9 @@ def _cmd_list_formats(app: Facade, args) -> int:
     print(f"{'ID':>3s}  {'格式':12s} {'编码':>5s}  {'码率':>6s}  {'文件大小':>10s}")
     print(f"{'---':3s}  {'----------':12s} {'-----':>5s}  {'------':>6s}  {'----------':>10s}")
     for i, f in enumerate(formats):
-        parts = f["type"].split("_")
-        codec = parts[0] if parts else "?"
-        bitrate = parts[1] if len(parts) >= 2 else "?"
+        bitrate = f"{f['bitrate']}k" if f["bitrate"] > 0 else "?"
         size_str = _fmt_size(f["file_size"])
-        print(f"{i:3d}  {f['type']:12s} {codec:>5s}  {bitrate + 'k':>6s}  {size_str:>10s}")
+        print(f"{i:3d}  {f['type']:12s} {f['codec']:>5s}  {bitrate:>6s}  {size_str:>10s}")
     print()
     print(f"共 {len(formats)} 种格式")
     return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,20 +7,63 @@ import pytest
 from xdl.application.usecases import AlbumResult
 from xdl.errors import AuthError
 from xdl.frontends.cli import (_cmd_album, _cmd_refresh_cookies, _cmd_resume,
-                               _cmd_risk_report, build_parser, main)
+                               _cmd_risk_report, _cmd_track, _fmt_size,
+                               build_parser, main)
 from xdl.settings import Settings
 
 
 class FakeApp:
-    def __init__(self, album_result=None, resume_results=None):
+    def __init__(self, album_result=None, resume_results=None, formats_info=None):
         self.album_result = album_result
         self.resume_results = resume_results or []
+        self.formats_info = formats_info
+        self.download_track_calls = 0
 
     def download_album(self, target, quality=None, range_=None, reporter=None):
         return self.album_result
 
     def resume(self, reporter=None):
         return self.resume_results
+
+    def list_formats(self, target):
+        return self.formats_info
+
+    def download_track(self, target, quality=None, reporter=None):
+        self.download_track_calls += 1
+        return "downloaded.mp3"
+
+
+def test_track_list_formats_uses_facade_result_without_downloading(capsys):
+    app = FakeApp(formats_info={
+        "title": "曲目",
+        "track_id": "123",
+        "default_quality": "standard",
+        "formats": [
+            {"type": "M4A_64", "codec": "M4A", "bitrate": 64,
+             "file_size": 2 * 1024 * 1024},
+            {"type": "LOSSLESS", "codec": "LOSSLESS", "bitrate": 0,
+             "file_size": 0},
+        ],
+    })
+    args = build_parser().parse_args(["track", "-F", "123"])
+
+    assert _cmd_track(app, args) == 0
+
+    output = capsys.readouterr().out
+    assert app.download_track_calls == 0
+    assert output.index("M4A_64") < output.index("LOSSLESS")
+    assert "64k" in output
+    assert "未知" in output
+
+
+@pytest.mark.parametrize(("size", "expected"), [
+    (0, "未知"),
+    (512, "512 B"),
+    (1024, "1.0 KB"),
+    (1024 * 1024, "1.0 MB"),
+])
+def test_fmt_size(size, expected):
+    assert _fmt_size(size) == expected
 
 
 def test_album_stop_prints_summary_before_130(capsys):

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -34,6 +34,26 @@ def test_playurl_ext():
     assert PlayUrl("MP3_64", "x.mp3").ext == ".mp3"
 
 
+def test_playurl_exposes_format_metadata():
+    assert PlayUrl("m4a_64", "x.m4a").codec == "M4A"
+    assert PlayUrl("m4a_64", "x.m4a").bitrate == 64
+    assert PlayUrl("LOSSLESS", "x.bin").codec == "LOSSLESS"
+    assert PlayUrl("LOSSLESS", "x.bin").bitrate == 0
+
+
+def test_track_available_play_urls_are_filtered_and_ranked():
+    track = Track("1", "标题", [
+        PlayUrl("MP3_32", "u32"),
+        PlayUrl("M4A_64", "u64"),
+        PlayUrl("MP3_128", ""),
+        PlayUrl("LOSSLESS", "unknown"),
+    ])
+
+    assert [p.type for p in track.available_play_urls()] == [
+        "M4A_64", "MP3_32", "LOSSLESS",
+    ]
+
+
 @pytest.mark.parametrize("raw,expected", [
     ("123456", "123456"),
     ("https://www.ximalaya.com/sound/789", "789"),

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -2,6 +2,8 @@
 """Facade 装配行为测试。"""
 import os
 
+import pytest
+
 from xdl.application import Facade
 from xdl.domain import Track, PlayUrl
 from xdl.settings import Settings
@@ -9,9 +11,11 @@ from xdl.errors import ConfigError
 
 
 class FakeSource:
-    def __init__(self):
+    def __init__(self, track=None, error=None):
         self.opened = 0
         self.closed = 0
+        self.track = track
+        self.error = error
 
     def interactive_login(self):
         return "/tmp/xdl-profile"
@@ -23,8 +27,13 @@ class FakeSource:
         self.closed += 1
 
     async def get_track(self, track_id):
-        return Track(track_id=track_id, title="曲目",
-                     play_urls=[PlayUrl("MP3_64", "http://x/a.mp3")])
+        if self.error is not None:
+            raise self.error
+        return self.track or Track(
+            track_id=track_id,
+            title="曲目",
+            play_urls=[PlayUrl("MP3_64", "http://x/a.mp3")],
+        )
 
 
 class FakeSink:
@@ -59,15 +68,48 @@ def test_track_tolerates_broken_store(tmp_path):
     assert path.endswith(".mp3")
 
 
-def test_unknown_source_backend_fails_fast():
-    import pytest
+def test_list_formats_returns_ranked_structured_formats_and_closes_source():
+    source = FakeSource(Track("123", "曲目", [
+        PlayUrl("MP3_32", "http://x/32.mp3", 1024),
+        PlayUrl("M4A_64", "http://x/64.m4a", 2048),
+        PlayUrl("MP3_128", "", 4096),
+        PlayUrl("LOSSLESS", "http://x/lossless", 0),
+    ]))
+    app = Facade(source, FakeSink(), Settings(default_quality="high"))
 
+    info = app.list_formats("https://www.ximalaya.com/sound/123")
+
+    assert info == {
+        "title": "曲目",
+        "track_id": "123",
+        "formats": [
+            {"type": "M4A_64", "codec": "M4A", "bitrate": 64,
+             "file_size": 2048},
+            {"type": "MP3_32", "codec": "MP3", "bitrate": 32,
+             "file_size": 1024},
+            {"type": "LOSSLESS", "codec": "LOSSLESS", "bitrate": 0,
+             "file_size": 0},
+        ],
+        "default_quality": "high",
+    }
+    assert (source.opened, source.closed) == (1, 1)
+
+
+def test_list_formats_closes_source_when_track_lookup_fails():
+    source = FakeSource(error=RuntimeError("boom"))
+    app = Facade(source, FakeSink(), Settings())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        app.list_formats("123")
+
+    assert (source.opened, source.closed) == (1, 1)
+
+
+def test_unknown_source_backend_fails_fast():
     with pytest.raises(ConfigError, match="未知音源后端"):
         Facade.from_config(Settings(source_backend="typo"))
 
 
 def test_settings_rejects_non_positive_concurrency():
-    import pytest
-
     with pytest.raises(ConfigError, match="并发数"):
         Settings(max_concurrency=0)


### PR DESCRIPTION
类似 yt-dlp -F 的功能。

## 用法

```bash
xdl track -F <链接或trackId>
```

## 输出示例

```
曲目: 三体-全集
ID: 12345678
默认音质: standard

 ID  格式           编码    码率    文件大小
---  ----------  -----  ------  ----------
  0  M4A_64       M4A     64k      12.3 MB
  1  MP3_64       MP3     64k      12.3 MB
  2  MP3_32       MP3     32k       6.2 MB
  3  M4A_24       M4A     24k       4.6 MB

共 4 种格式
```

按码率+编码优先级降序排列，与现有 Quality.negotiate() 排序一致。

## 改动

- `Facade.list_formats()`: 打开音源获取 Track 全部 play_urls，返回格式清单
- CLI track 子命令新增 `-F` / `--list-formats` 选项