### PR TITLE
fix: 登录闪退、无法登出换号，以及 PC 后端风控观测从未落盘

### DIFF
--- a/src/xdl/adapters/sign/cookies.py
+++ b/src/xdl/adapters/sign/cookies.py
@@ -264,6 +264,19 @@ def save_cookies(cookies: list[dict], path: str) -> None:
             os.unlink(temp_path)
 
 
+def clear_cookie_cache(path: str) -> bool:
+    """删除 Cookie 缓存文件；本来就不存在时返回 False 而不是报错。"""
+    if not path:
+        return False
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return False
+    except IsADirectoryError as exc:
+        raise ValueError(f"cookies_cache_path 指向目录，拒绝删除: {path}") from exc
+    return True
+
+
 def load_cached_cookies(path: str, max_age_seconds: int = 1800) -> list[dict] | None:
     """若缓存文件存在且足够新鲜则返回内容，否则返回 None。"""
     if not os.path.exists(path):

--- a/src/xdl/adapters/source_chrome.py
+++ b/src/xdl/adapters/source_chrome.py
@@ -67,21 +67,32 @@ def _cancel_requested(cancel) -> bool:
     return bool(cancel())
 
 
-def wipe_browser_profile(profile_dir: str) -> bool:
+def wipe_browser_profile(profile_dir: str, *, port: int | None = None,
+                         browser_name: str = "浏览器") -> bool:
     """删除专用浏览器 Profile 目录；删掉了返回 True。
 
     这是"登出"的关键一步：只清 Cookie 缓存文件是不够的，Profile 里还留着上一
     个账号的会话，下次打开浏览器会直接自动登录回去，根本换不了号。
 
-    只删 xdl 自己创建的专用 Profile，所以先要求目录里存在 Chrome user-data-dir
-    的标志物（`Local State` 或 `Default/`）。少了这道闸，一旦 chrome_profile_dir
-    被误配成家目录之类的路径，这里就会递归删掉用户的真实数据。
+    两道闸，缺一不可：
+
+    - 只删 xdl 自己创建的专用 Profile：要求目录里存在 Chrome user-data-dir
+      的标志物（`Local State` 或 `Default/`）。少了这道闸，一旦
+      chrome_profile_dir 被误配成家目录之类的路径，这里就会递归删掉真实数据。
+    - 传入 ``port`` 时先确认调试端口已无浏览器占用：浏览器仍在运行时删掉
+      Profile，它退出时会把旧登录态重新写回来，登出就白做了。调用方知道端口
+      就该传进来，不能只在上一层检查——直接调用本函数也必须安全。
     """
     import shutil
 
     path = Path(profile_dir or "")
     if not profile_dir or not path.is_dir():
         return False
+    if port is not None and _port_alive(port):
+        raise ConfigError(
+            f"{browser_name} 调试端口 {port} 仍被占用；"
+            "请先关闭该浏览器窗口再清除 Profile，否则登录态会被重新写回。"
+        )
     resolved = path.resolve()
     if resolved.parent == resolved:      # 文件系统根
         raise ConfigError(f"拒绝删除根目录级 Profile 路径: {resolved}")
@@ -728,11 +739,6 @@ class ChromeSource:
         if detail.get("profile_removed"):
             announce(f"已清除专用 {self._browser_name} Profile 中的旧登录态。")
         os.makedirs(self._profile_dir, exist_ok=True)
-        if _port_alive(self._port):
-            raise NetworkError(
-                f"{self._browser_name} 调试端口 {self._port} 已被占用，"
-                "请先关闭占用该端口的浏览器。"
-            )
         announce(f"已打开 {self._browser_name}，请在其中完成登录（扫码或账号密码）；"
                  "检测到登录态后浏览器会自动关闭。")
         args = [self._chrome_path,
@@ -790,13 +796,13 @@ class ChromeSource:
         return [dict(cookie) for cookie in cookies]
 
     def logout(self) -> dict:
-        """登出＝删掉专用 Profile。平台侧没有可调的登出接口，本地凭据即登录态。"""
-        if _port_alive(self._port):
-            raise ConfigError(
-                f"{self._browser_name} 调试端口 {self._port} 仍被占用；"
-                "请先关闭该浏览器窗口再登出，否则 Profile 会被重新写回。"
-            )
-        removed = wipe_browser_profile(self._profile_dir)
+        """登出＝删掉专用 Profile。平台侧没有可调的登出接口，本地凭据即登录态。
+
+        浏览器仍在运行时的拒绝删守卫在 wipe_browser_profile 内部（传入端口即
+        启用），直接调用底层函数也绕不过。
+        """
+        removed = wipe_browser_profile(
+            self._profile_dir, port=self._port, browser_name=self._browser_name)
         self._login_cookies = []
         self._authenticated = None
         return {"profile_removed": removed, "profile_dir": self._profile_dir}

--- a/src/xdl/adapters/source_chrome.py
+++ b/src/xdl/adapters/source_chrome.py
@@ -36,8 +36,8 @@ import requests
 
 from ..config import platform
 from ..domain import Track, PlayUrl, Album, AlbumTrack
-from ..errors import (XdlError, ApiError, AuthError, NetworkError, ConfigError,
-                      RiskControlError)
+from ..errors import (XdlError, ApiError, AuthError, CancelledByUser,
+                      NetworkError, ConfigError, RiskControlError)
 from ..ports import Decoder
 from ..risk import RiskEventRecorder
 from .sign.cookies import (
@@ -55,6 +55,45 @@ def _port_alive(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.settimeout(0.5)
         return s.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _cancel_requested(cancel) -> bool:
+    """`cancel` 可能是 threading.Event（Web 运行器）或普通可调用对象（CLI）。"""
+    if cancel is None:
+        return False
+    is_set = getattr(cancel, "is_set", None)
+    if callable(is_set):
+        return bool(is_set())
+    return bool(cancel())
+
+
+def wipe_browser_profile(profile_dir: str) -> bool:
+    """删除专用浏览器 Profile 目录；删掉了返回 True。
+
+    这是"登出"的关键一步：只清 Cookie 缓存文件是不够的，Profile 里还留着上一
+    个账号的会话，下次打开浏览器会直接自动登录回去，根本换不了号。
+
+    只删 xdl 自己创建的专用 Profile，所以先要求目录里存在 Chrome user-data-dir
+    的标志物（`Local State` 或 `Default/`）。少了这道闸，一旦 chrome_profile_dir
+    被误配成家目录之类的路径，这里就会递归删掉用户的真实数据。
+    """
+    import shutil
+
+    path = Path(profile_dir or "")
+    if not profile_dir or not path.is_dir():
+        return False
+    resolved = path.resolve()
+    if resolved.parent == resolved:      # 文件系统根
+        raise ConfigError(f"拒绝删除根目录级 Profile 路径: {resolved}")
+    markers = ((resolved / "Local State").exists(),
+               (resolved / "Default").is_dir())
+    if not any(markers):
+        raise ConfigError(
+            f"{resolved} 看起来不是浏览器专用 Profile（缺少 Local State / Default），"
+            "为避免误删已跳过；请检查 chrome_profile_dir 配置。"
+        )
+    shutil.rmtree(resolved)
+    return True
 
 
 def _has_login_cookie(cookies: list[dict]) -> bool:
@@ -662,16 +701,40 @@ class ChromeSource:
                      total=total or len(tracks), tracks=tracks)
 
     # ---- 适配器特有：交互式登录（同步，一次性） ----
-    def interactive_login(self) -> str:
+    def interactive_login(self, *, reset: bool = False, cancel=None,
+                          notify=None, wait_timeout: float = 600.0) -> str:
+        """打开专用浏览器等待用户登录，检测到登录 token 后自动收尾。
+
+        等待方式是**轮询 CDP**，不是读终端。原来这里 `input()` 等回车，在 WebUI
+        下是致命的：服务进程没有 tty，`input()` 立刻抛 EOFError，finally 随即
+        终止浏览器——用户看到的就是"窗口一闪就关"。轮询让 CLI 与 WebUI 共用一
+        条路径，用户也不必再切回终端按回车。
+
+        `reset=True` 是"换账号"：先清掉专用 Profile 再开浏览器。不清的话，
+        Profile 里旧账号的 token 会让第一轮轮询立刻命中，浏览器一闪即关，
+        保存下来的还是同一个账号——换号根本换不掉。
+        """
+        announce = notify or print
         self._login_cookies = []
         self._require_chrome()
+        if reset:
+            detail = self.logout()
+            if detail.get("profile_removed"):
+                announce(f"已清除专用 {self._browser_name} Profile 中的旧登录态。")
+        elif _has_persisted_login_cookie(self._profile_dir):
+            # 不吭声地"复用"会被误认为登录成功，而用户其实是想换号
+            announce(
+                f"专用 {self._browser_name} Profile 中已有登录态，将直接复用；"
+                "要换成另一个账号，请使用“换账号”。"
+            )
         os.makedirs(self._profile_dir, exist_ok=True)
         if _port_alive(self._port):
             raise NetworkError(
                 f"{self._browser_name} 调试端口 {self._port} 已被占用，"
                 "请先关闭占用该端口的浏览器。"
             )
-        print(f"即将打开 {self._browser_name}，请在其中完成登录（扫码或账号密码）。")
+        announce(f"已打开 {self._browser_name}，请在其中完成登录（扫码或账号密码）；"
+                 "检测到登录态后浏览器会自动关闭。")
         args = [self._chrome_path,
                 f"--remote-debugging-port={self._port}",
                 f"--user-data-dir={self._profile_dir}",
@@ -689,12 +752,15 @@ class ChromeSource:
                 raise NetworkError(
                     f"{self._browser_name} 调试端口 {self._port} 未就绪（启动超时）。")
 
-            while not verified:
-                input(">>> 登录完成后回到这里按回车，程序将验证登录状态: ")
-                verified = self._verify_interactive_login()
-                if not verified:
-                    print(f"未检测到专用 {self._browser_name} 的登录状态，"
-                          "请在该窗口继续登录后重试。")
+            verified = self._await_interactive_login(
+                proc, cancel=cancel, announce=announce,
+                deadline=time.monotonic() + max(10.0, float(wait_timeout)),
+            )
+            if not verified:
+                raise AuthError(
+                    f"等待登录超时（{int(wait_timeout)} 秒），未在专用 "
+                    f"{self._browser_name} 中检测到登录态；请重试。"
+                )
         finally:
             # 验证成功时 _verify_interactive_login 已通过 CDP 正常关闭浏览器，
             # 只等待其退出，异常/中断时才使用终止作为兜底。
@@ -723,31 +789,66 @@ class ChromeSource:
         cookies, self._login_cookies = self._login_cookies, []
         return [dict(cookie) for cookie in cookies]
 
-    def _verify_interactive_login(self) -> bool:
-        """连接专用 Chrome 验证登录；成功后正常关闭浏览器以确保 Profile 刷盘。"""
+    def logout(self) -> dict:
+        """登出＝删掉专用 Profile。平台侧没有可调的登出接口，本地凭据即登录态。"""
+        if _port_alive(self._port):
+            raise ConfigError(
+                f"{self._browser_name} 调试端口 {self._port} 仍被占用；"
+                "请先关闭该浏览器窗口再登出，否则 Profile 会被重新写回。"
+            )
+        removed = wipe_browser_profile(self._profile_dir)
+        self._login_cookies = []
+        self._authenticated = None
+        return {"profile_removed": removed, "profile_dir": self._profile_dir}
+
+    def _await_interactive_login(self, proc, *, cancel, announce, deadline,
+                                 poll_interval: float = 1.5) -> bool:
+        """轮询专用浏览器直到出现登录 token；成功后正常关闭浏览器以确保刷盘。
+
+        全程只保持一条 CDP 连接：每轮重连会拖慢轮询，也更容易撞上 Chrome 的
+        调试端口限流。
+        """
         from playwright.sync_api import sync_playwright
 
+        self._login_cookies = []
+        reminded = False
         with sync_playwright() as pw:
             browser = pw.chromium.connect_over_cdp(
                 f"http://127.0.0.1:{self._port}")
-            contexts = browser.contexts
-            if not contexts:
-                return False
-            context = contexts[0]
-            site_cookies = filter_cookies_for_domain(
-                context.cookies(), platform.BASE,
-            )
-            authenticated = _has_login_cookie(site_cookies)
-            if authenticated:
-                # connect_over_cdp() 取得的是远程 Chrome 连接；browser.close()
-                # 只会关闭 Playwright 连接，不能让由 interactive_login 启动的
-                # Chrome 进程退出。通过根 CDP 会话发送 Browser.close，才会走
-                # Chrome 自身的正常退出/落盘流程。
-                browser.new_browser_cdp_session().send("Browser.close")
-                self._login_cookies = [dict(cookie) for cookie in site_cookies]
-            else:
-                self._login_cookies = []
-            return authenticated
+            while True:
+                if _cancel_requested(cancel):
+                    raise CancelledByUser("登录已取消。")
+                if proc.poll() is not None:
+                    # 用户自己把窗口关了：继续轮询只会空转到超时
+                    raise AuthError(
+                        f"{self._browser_name} 已关闭，登录未完成。"
+                    )
+                try:
+                    contexts = browser.contexts
+                    site_cookies = filter_cookies_for_domain(
+                        contexts[0].cookies(), platform.BASE,
+                    ) if contexts else []
+                except Exception as exc:
+                    raise AuthError(
+                        f"与专用 {self._browser_name} 的调试连接已断开，"
+                        f"登录未完成：{exc}"
+                    ) from exc
+                if _has_login_cookie(site_cookies):
+                    # connect_over_cdp() 取得的是远程 Chrome 连接；browser.close()
+                    # 只会关闭 Playwright 连接，不能让由 interactive_login 启动的
+                    # Chrome 进程退出。通过根 CDP 会话发送 Browser.close，才会走
+                    # Chrome 自身的正常退出/落盘流程。
+                    self._login_cookies = [dict(cookie) for cookie in site_cookies]
+                    browser.new_browser_cdp_session().send("Browser.close")
+                    announce("已检测到登录态，正在关闭浏览器并保存凭据…")
+                    return True
+                if time.monotonic() > deadline:
+                    return False
+                if not reminded and time.monotonic() > deadline - 540:
+                    announce(f"仍在等待登录…请在打开的 {self._browser_name} 窗口中"
+                             "完成登录，完成后无需回到这里操作。")
+                    reminded = True
+                time.sleep(poll_interval)
 
     @staticmethod
     def _terminate_process(proc) -> None:
@@ -1056,6 +1157,7 @@ class ChromeSource:
                 request_index=request_index,
                 started_at=started_at,
                 authenticated=self._authenticated,
+                backend="chrome",
                 device_fingerprint_reset=self._device_fingerprint_was_reset,
             )
         except OSError:

--- a/src/xdl/adapters/source_chrome.py
+++ b/src/xdl/adapters/source_chrome.py
@@ -710,23 +710,23 @@ class ChromeSource:
         终止浏览器——用户看到的就是"窗口一闪就关"。轮询让 CLI 与 WebUI 共用一
         条路径，用户也不必再切回终端按回车。
 
-        `reset=True` 是"换账号"：先清掉专用 Profile 再开浏览器。不清的话，
-        Profile 里旧账号的 token 会让第一轮轮询立刻命中，浏览器一闪即关，
-        保存下来的还是同一个账号——换号根本换不掉。
+        登录**总是先清掉专用 Profile** 再开浏览器：Profile 里只要留着旧账号的
+        token，第一轮轮询就会立刻命中、浏览器一闪即关，保存下来的还是同一个
+        账号——用户想换号时根本换不掉。"换账号"因此不再是一个独立分支：先登出
+        （删 Profile）再登录（重新扫码）即可。`reset` 参数保留仅为向后兼容
+        现有调用方，行为上已无差异。
         """
         announce = notify or print
         self._login_cookies = []
         self._require_chrome()
-        if reset:
-            detail = self.logout()
-            if detail.get("profile_removed"):
-                announce(f"已清除专用 {self._browser_name} Profile 中的旧登录态。")
-        elif _has_persisted_login_cookie(self._profile_dir):
-            # 不吭声地"复用"会被误认为登录成功，而用户其实是想换号
-            announce(
-                f"专用 {self._browser_name} Profile 中已有登录态，将直接复用；"
-                "要换成另一个账号，请使用“换账号”。"
+        if _port_alive(self._port):
+            raise NetworkError(
+                f"{self._browser_name} 调试端口 {self._port} 已被占用，"
+                "请先关闭占用该端口的浏览器。"
             )
+        detail = self.logout()
+        if detail.get("profile_removed"):
+            announce(f"已清除专用 {self._browser_name} Profile 中的旧登录态。")
         os.makedirs(self._profile_dir, exist_ok=True)
         if _port_alive(self._port):
             raise NetworkError(

--- a/src/xdl/adapters/source_http.py
+++ b/src/xdl/adapters/source_http.py
@@ -689,9 +689,11 @@ class HttpSource:
             raise ConfigError(
                 "未配置 chrome_fallback；无法在纯 HTTP 后端下交互登录。"
                 "请确认装配根注入了 ChromeSource（见 composition.build_facade）。")
-        if wait_options.pop("reset", False):
-            # 换账号：Cookie 缓存和 Profile 一起清，只清一个都会被旧账号顶回来
-            self.logout()
+        # ChromeSource 的登录总是先清专用 Profile（见其实现 docstring），这里只需
+        # 额外清掉 Cookie 缓存——只清一个都会被旧账号顶回来：清了 Profile 不清缓存，
+        # 下次 open() 会从缓存重新装回旧会话。
+        wait_options.pop("reset", None)  # 向后兼容旧调用方；行为上已无差异
+        clear_cookie_cache(self._cookies_cache_path)
         path = self._chrome_fallback.interactive_login(**wait_options)
         # Cookie 已在登录浏览器仍存活时捕获。这里绝不能为导出而重启 Profile：
         # Playwright 的测试用 Keychain 参数与系统浏览器不同，会在 macOS 上清掉

--- a/src/xdl/adapters/source_http.py
+++ b/src/xdl/adapters/source_http.py
@@ -28,7 +28,8 @@ from ..errors import (ApiError, AuthError, ConfigError, NetworkError,
                       RiskControlError, SignError)
 from ..ports import Decoder, SignProvider
 from ..risk import RiskEventRecorder
-from .sign.cookies import (build_cookie_header, extract_cookies_from_profile,
+from .sign.cookies import (build_cookie_header, clear_cookie_cache,
+                           extract_cookies_from_profile,
                            load_cached_cookies, save_cookies, is_login_cookie,
                            login_cookies_only, strip_device_cookies)
 from .sign.extractor import (compare_device_identities, count_device_cookies,
@@ -676,7 +677,7 @@ class HttpSource:
         return await asyncio.to_thread(_fetch_album_list, str(album_id))
 
     # ---- 与音源后端无关的命令（委托给 ChromeSource 兜底） ----
-    def interactive_login(self) -> str:
+    def interactive_login(self, **wait_options) -> str:
         """打开浏览器完成登录、保存到专用 Profile（共用 `xdl login` 流程）。
 
         登录态与音源后端无关：HttpSource 只是从这个 Profile 提取登录 Cookie
@@ -688,7 +689,10 @@ class HttpSource:
             raise ConfigError(
                 "未配置 chrome_fallback；无法在纯 HTTP 后端下交互登录。"
                 "请确认装配根注入了 ChromeSource（见 composition.build_facade）。")
-        path = self._chrome_fallback.interactive_login()
+        if wait_options.pop("reset", False):
+            # 换账号：Cookie 缓存和 Profile 一起清，只清一个都会被旧账号顶回来
+            self.logout()
+        path = self._chrome_fallback.interactive_login(**wait_options)
         # Cookie 已在登录浏览器仍存活时捕获。这里绝不能为导出而重启 Profile：
         # Playwright 的测试用 Keychain 参数与系统浏览器不同，会在 macOS 上清掉
         # 无法解密的 Cookie；会话 Cookie 即使加密兼容也未必能跨重启恢复。
@@ -704,6 +708,21 @@ class HttpSource:
         self._install_cookies(cookies, strip_device=self._experiment_strip_cookies)
         self._collect_device_info_if_missing()
         return path
+
+    def logout(self) -> dict:
+        """清掉本地登录凭据：Cookie 缓存 + 专用 Profile + 内存副本。
+
+        三处缺一不可——只删缓存文件，下次 open() 会从 Profile 重新导出同一个
+        账号；只删 Profile，内存里的 Cookie 头还在本进程里继续用。
+        """
+        removed_cache = clear_cookie_cache(self._cookies_cache_path)
+        profile = ({} if self._chrome_fallback is None
+                   else self._chrome_fallback.logout())
+        self._cookies = []
+        self._cookie_header = ""
+        self._authenticated = False
+        return {"cookie_cache_removed": removed_cache,
+                "cookie_cache_path": self._cookies_cache_path, **profile}
 
     def _collect_device_info_if_missing(self) -> None:
         """登录后补齐该浏览器的设备指纹（仅在缺失时采集，不覆盖已有文件）。
@@ -784,6 +803,7 @@ class HttpSource:
                 request_index=request_index,
                 started_at=started_at,
                 authenticated=self._authenticated,
+                backend="http",
                 device_fingerprint_reset=self._device_fingerprint_was_reset,
             )
         except OSError:

--- a/src/xdl/adapters/source_pc.py
+++ b/src/xdl/adapters/source_pc.py
@@ -518,9 +518,10 @@ class PcHttpSource:
             raise ConfigError(
                 "未配置 chrome_fallback；无法在 pc 后端下交互登录。"
                 "请确认装配根注入了 ChromeSource（见 composition.build_facade）。")
-        if wait_options.pop("reset", False):
-            # 换账号：Cookie 缓存和 Profile 一起清，只清一个都会被旧账号顶回来
-            self.logout()
+        # ChromeSource 的登录总是先清专用 Profile（见其实现 docstring），这里只需
+        # 额外清掉 Cookie 缓存——只清一个都会被旧账号顶回来。
+        wait_options.pop("reset", None)  # 向后兼容旧调用方；行为上已无差异
+        clear_cookie_cache(self._cookies_cache_path)
         path = self._chrome_fallback.interactive_login(**wait_options)
         take_cookies = getattr(self._chrome_fallback, "take_login_cookies", None)
         if not callable(take_cookies):

--- a/src/xdl/adapters/source_pc.py
+++ b/src/xdl/adapters/source_pc.py
@@ -35,7 +35,8 @@ from ..errors import (ApiError, AuthError, ConfigError, DecodeError,
 from ..risk import RiskEventRecorder
 from .decoder import WinEcbDecoder
 from .sign.py_sign import PySignProvider
-from .sign.cookies import (build_cookie_header, extract_cookies_from_profile,
+from .sign.cookies import (build_cookie_header, clear_cookie_cache,
+                           extract_cookies_from_profile,
                            ensure_pc_device_cookies, is_login_cookie,
                            load_cached_cookies, save_cookies)
 
@@ -511,13 +512,16 @@ class PcHttpSource:
         )
 
     # ---- 与音源后端无关的命令（委托给 ChromeSource 兜底） ----
-    def interactive_login(self) -> str:
+    def interactive_login(self, **wait_options) -> str:
         """打开浏览器完成登录并保存到专用 Profile（共用 `xdl login` 流程）。"""
         if self._chrome_fallback is None:
             raise ConfigError(
                 "未配置 chrome_fallback；无法在 pc 后端下交互登录。"
                 "请确认装配根注入了 ChromeSource（见 composition.build_facade）。")
-        path = self._chrome_fallback.interactive_login()
+        if wait_options.pop("reset", False):
+            # 换账号：Cookie 缓存和 Profile 一起清，只清一个都会被旧账号顶回来
+            self.logout()
+        path = self._chrome_fallback.interactive_login(**wait_options)
         take_cookies = getattr(self._chrome_fallback, "take_login_cookies", None)
         if not callable(take_cookies):
             raise ConfigError(
@@ -537,6 +541,21 @@ class PcHttpSource:
         self._authenticated = True
         return path
 
+    def logout(self) -> dict:
+        """清掉本地登录凭据：Cookie 缓存 + 专用 Profile + 内存副本。
+
+        三处缺一不可——只删缓存文件，下次 open() 会从 Profile 重新导出同一个
+        账号；只删 Profile，内存里的 Cookie 头还在本进程里继续用。
+        """
+        removed_cache = clear_cookie_cache(self._cookies_cache_path)
+        profile = ({} if self._chrome_fallback is None
+                   else self._chrome_fallback.logout())
+        self._cookies = []
+        self._cookie_header = ""
+        self._authenticated = False
+        return {"cookie_cache_removed": removed_cache,
+                "cookie_cache_path": self._cookies_cache_path, **profile}
+
     async def inspect_storage(self) -> dict:
         """诊断：列出 Profile 设备标识存储 key（不读 value），委托 ChromeSource。"""
         if self._chrome_fallback is None:
@@ -555,13 +574,18 @@ class PcHttpSource:
                 elapsed_ms=round((time.perf_counter() - started) * 1000),
                 outcome=outcome,
                 ret=ret,
-                message=str(msg or ""),
+                msg=str(msg or ""),
                 in_flight=1,
                 started_at=datetime.now(timezone.utc).isoformat(),
                 request_index=request_index,
                 session_id=self._session_id,
+                authenticated=self._authenticated,
+                backend="pc",
             )
-        except Exception:
+        # 只吞写盘失败。这里原本 catch Exception 并且传的是 `message=`（record()
+        # 的参数叫 msg），于是每次调用都抛 TypeError 被静默吃掉——PC 后端从头到尾
+        # 一条观测都没落盘。catch 收窄后，同类签名错误会立刻炸出来而不是装作没事。
+        except OSError:
             pass
 
     def _record_album(self, album_id: str, outcome: str, ret, msg) -> None:
@@ -573,11 +597,13 @@ class PcHttpSource:
                 elapsed_ms=0,
                 outcome=outcome,
                 ret=ret,
-                message=str(msg or ""),
+                msg=str(msg or ""),
                 in_flight=1,
                 started_at=datetime.now(timezone.utc).isoformat(),
                 request_index=self._request_index,
                 session_id=self._session_id,
+                authenticated=self._authenticated,
+                backend="pc",
             )
-        except Exception:
+        except OSError:
             pass

--- a/src/xdl/application/diagnostics.py
+++ b/src/xdl/application/diagnostics.py
@@ -101,7 +101,13 @@ def _other_browser_with_login(settings: Settings, current: str) -> str | None:
 
 
 def login_cache_status(settings: Settings) -> dict:
-    """报告**当前浏览器**的本地登录缓存状态，不暴露 Cookie 名或值。"""
+    """报告**当前浏览器**的本地登录状态，不暴露 Cookie 名或值。
+
+    登录态的存放位置按后端分家：http/pc 登录后把 Cookie 拷进缓存文件；chrome
+    后端从头到尾只依赖专用 Profile 的 Cookie DB（不写缓存文件）。所以
+    ``authenticated`` 必须按后端分别检查，否则 chrome 后端会恒报未登录——
+    前端据此藏起登出入口、把"换账号"走成普通登录，旧账号被静默续存。
+    """
     path = settings.cookies_cache_path
     exists = os.path.isfile(path)
     age_seconds = None
@@ -112,10 +118,16 @@ def login_cache_status(settings: Settings) -> dict:
         except OSError:
             age_seconds = None
     current = _resolved_browser(settings)
+    if settings.source_backend == "chrome":
+        # 延迟导入：diagnostics 是应用层模块，不能在导入期就拉上浏览器适配器。
+        from ..adapters.source_chrome import _has_persisted_login_cookie
+        authenticated = _has_persisted_login_cookie(settings.chrome_profile_dir)
+    else:
+        authenticated = _has_login_cache(path)
     return {
         "browser": current,
         "browser_name": platform.browser_display_name(current),
-        "authenticated": _has_login_cache(path),
+        "authenticated": authenticated,
         "cache_exists": exists,
         "cache_age_seconds": age_seconds,
         "profile_exists": os.path.isdir(settings.chrome_profile_dir),

--- a/src/xdl/application/facade.py
+++ b/src/xdl/application/facade.py
@@ -52,9 +52,32 @@ class Facade:
             max_duration=s.risk_poll_max_duration,
         )
 
-    def login(self) -> str:
-        """打开浏览器登录并保存会话，返回保存路径。"""
-        return self._source.interactive_login()
+    def login(self, *, reset: bool = False, cancel=None, notify=None) -> str:
+        """打开浏览器登录并保存会话，返回保存路径。
+
+        `cancel`/`notify` 让无终端的前端（WebUI）也能等待并中断这段交互；
+        不传就是 CLI 的老行为（打印到 stdout、不可中断）。
+        `reset=True` 表示换账号：先清掉现有登录凭据再登录。
+        """
+        return self._source.interactive_login(
+            reset=reset, cancel=cancel, notify=notify)
+
+    def auth_status(self) -> dict:
+        """当前音源的登录态；音源未实现时按“未登录”回报。"""
+        method = getattr(self._source, "auth_status", None)
+        if method is None:
+            return {"backend": self._settings.source_backend,
+                    "authenticated": False, "multi_step": False}
+        return method()
+
+    def logout(self) -> dict:
+        method = getattr(self._source, "logout", None)
+        if method is None:
+            raise XdlError("当前音源不支持独立登出。")
+        # 后端的 logout 会回报清掉了哪些凭据（Cookie 缓存 / Profile），一并带
+        # 出去，前端才能说清“到底删了什么”。
+        detail = method() or {}
+        return {**self.auth_status(), **detail}
 
     def download_track(self, target: str, quality: str | None = None,
                        reporter=None, cancel: threading.Event | None = None) -> str:

--- a/src/xdl/application/usecases.py
+++ b/src/xdl/application/usecases.py
@@ -132,6 +132,9 @@ async def _await_risk_recovery(source: Source, probe_track_ids: list[str],
                 await source.get_track(probe_id)
                 # 首次探针且没有配置等待时，实际并没有"等"过；此时把探针自身的
                 # 耗时算成等待时长，会让 risk_wait_seconds 变成一个非零的噪声值。
+                # 前提：探针是串行的，"首次探针" ⇔ attempt == 1。若未来引入并行
+                # 探针，这个等价关系会静默失效，届时需要换成显式的"是否已等待过"
+                # 状态位来判定。
                 waited = (0.0 if policy.initial_wait <= 0 and attempt == 1
                           else time.monotonic() - started)
                 _note(reporter, f"  ✓ {label}风控已解除"

--- a/src/xdl/application/usecases.py
+++ b/src/xdl/application/usecases.py
@@ -130,7 +130,10 @@ async def _await_risk_recovery(source: Source, probe_track_ids: list[str],
             probe_id = candidates[0]
             try:
                 await source.get_track(probe_id)
-                waited = time.monotonic() - started
+                # 首次探针且没有配置等待时，实际并没有"等"过；此时把探针自身的
+                # 耗时算成等待时长，会让 risk_wait_seconds 变成一个非零的噪声值。
+                waited = (0.0 if policy.initial_wait <= 0 and attempt == 1
+                          else time.monotonic() - started)
                 _note(reporter, f"  ✓ {label}风控已解除"
                                 f"（等待 {waited:.0f}s），继续下载。")
                 return True, waited

--- a/src/xdl/frontends/cli.py
+++ b/src/xdl/frontends/cli.py
@@ -65,6 +65,19 @@ def _cmd_login(app: Facade, args) -> int:
     return 0
 
 
+def _cmd_logout(app: Facade, args) -> int:
+    """清除本机保存的登录凭据；换账号 = 先登出再重新登录。"""
+    detail = app.logout()
+    removed = [label for key, label in (
+        ("cookie_cache_removed", "Cookie 缓存"),
+        ("profile_removed", "专用浏览器 Profile"),
+    ) if detail.get(key)]
+    print("已登出：" + ("已清除 " + "、".join(removed) if removed
+                       else "本机没有可清除的登录凭据"))
+    print("如需登录另一个账号，请重新运行 `xdl login`。")
+    return 0
+
+
 def _maybe_print_browser_hint(args) -> None:
     """双浏览器机器且未显式选择时提示如何切换（浏览器选择只在登录时与用户相关）。"""
     if getattr(args, "browser", None):
@@ -287,7 +300,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(
         dest="command", required=True,
-        metavar="{web,login,track,album,resume,gen-sign,risk-report}",
+        metavar="{web,login,logout,track,album,resume,gen-sign,risk-report}",
     )
 
     p_web = sub.add_parser("web", help="启动本地 WebUI")
@@ -298,6 +311,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_web.add_argument("--no-open", action="store_true",
                        help="启动后不自动打开浏览器")
     sub.add_parser("login", help="打开浏览器登录并保存会话")
+    sub.add_parser("logout", help="清除本机保存的登录凭据（换账号：先登出再登录）")
     p_track = sub.add_parser("track", help="下载单个音频")
     p_track.add_argument("target", help="音频链接或 trackId")
     p_track.add_argument("--quality", choices=["high", "standard", "low"],
@@ -390,6 +404,7 @@ def main(argv: list[str] | None = None) -> int:
     handlers = {
         "web": _cmd_web,
         "login": _cmd_login,
+        "logout": _cmd_logout,
         "track": _cmd_track,
         "album": _cmd_album,
         "resume": _cmd_resume,
@@ -402,7 +417,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         # 本地诊断命令不需要装配下载器，避免无谓初始化 Chrome/任务库/HTTP 后端。
         app = (Facade.from_config(settings)
-               if args.command in {"login", "track", "album", "resume", "inspect"}
+               if args.command in {"login", "logout", "track", "album", "resume",
+                                   "inspect"}
                else None)
         return handlers[args.command](app, args)
     except CancelledByUser as e:

--- a/src/xdl/frontends/web.py
+++ b/src/xdl/frontends/web.py
@@ -51,6 +51,12 @@ class RefreshCookiesRequest(StrictModel):
     headless: bool = True
 
 
+class LoginRequest(StrictModel):
+    # 换账号：先清掉现有凭据再开浏览器。不清的话 Profile 里的旧 token 会让
+    # 登录轮询秒命中，浏览器一闪即关，存下来的还是同一个账号。
+    switch_account: bool = False
+
+
 class OpenDownloadsRequest(StrictModel):
     task_id: int | None = None
 
@@ -192,8 +198,14 @@ def create_app(runtime: WebRuntime | None = None) -> FastAPI:
         return service.risk_report()
 
     @app.post("/api/operations/login", status_code=202)
-    def login():
-        return service.start_login()
+    def login(body: LoginRequest | None = None):
+        return service.start_login(
+            switch_account=bool(body and body.switch_account))
+
+    @app.post("/api/auth/logout")
+    def logout():
+        """清除当前后端的登录态（浏览器 Cookie 缓存 + 专用 Profile）。"""
+        return service.logout()
 
     @app.post("/api/operations/download", status_code=202)
     def download(body: DownloadRequest):
@@ -239,7 +251,10 @@ def create_app(runtime: WebRuntime | None = None) -> FastAPI:
     @app.put("/api/settings")
     def update_settings(body: SettingsUpdate):
         changes = body.model_dump(exclude_unset=True, exclude_none=True)
-        return {"settings": service.update_settings(changes)}
+        settings = service.update_settings(changes)
+        # 顺带回传登录态：改 source_backend 会整套换掉登录体系，前端若继续沿用
+        # 保存前的 login，头部就会一直显示上一个后端的登录信息。
+        return {"settings": settings, "login": service.login_status()}
 
     @app.post("/api/open-downloads")
     def open_downloads(body: OpenDownloadsRequest):

--- a/src/xdl/frontends/web_runtime.py
+++ b/src/xdl/frontends/web_runtime.py
@@ -123,11 +123,19 @@ class WebRuntime:
     def settings(self) -> Settings:
         return self._settings
 
+    def login_status(self) -> dict:
+        """当前后端的登录态。
+
+        换后端可能等于换了一套登录态，所以这里单独成一个查询：改设置之后调用方
+        必须重新问一次，不能沿用 bootstrap 时的快照。
+        """
+        return login_cache_status(self._settings)
+
     def bootstrap(self) -> dict:
         tasks = self.tasks_snapshot()
         return {
             "settings": settings_dict(self._settings),
-            "login": login_cache_status(self._settings),
+            "login": self.login_status(),
             "operation": self.operation_snapshot(include_result=False),
             "tasks": tasks["tasks"],
             "counts": tasks["counts"],
@@ -217,12 +225,27 @@ class WebRuntime:
             "summary": summarize_risk_events(self._settings.risk_log_path),
         }
 
-    def start_login(self) -> dict:
-        def run(reporter, _cancel):
-            reporter.note("正在打开浏览器，请在浏览器中完成登录。")
-            path = self._facade.login()
-            return {"profile_path": path}
-        return self._start("login", "登录", False, run)
+    def start_login(self, *, switch_account: bool = False) -> dict:
+        def run(reporter, cancel):
+            reporter.note("正在清除旧登录态并打开浏览器…" if switch_account
+                          else "正在打开浏览器，请在浏览器中完成登录。")
+            # notify 走 reporter：登录等待的进度只有这条通道能到 WebUI。
+            # cancel 让"优雅停止"能中断等待，所以这个操作是 cancellable 的。
+            path = self._facade.login(reset=switch_account, cancel=cancel,
+                                      notify=reporter.note)
+            return {"profile_path": path, "switch_account": switch_account}
+        return self._start("login", "换账号登录" if switch_account else "登录",
+                           True, run)
+
+    def logout(self) -> dict:
+        """清除当前后端的登录态；返回清理明细 + 刷新后的登录态。"""
+        with self._lock:
+            if self._operation and self._operation["status"] == "running":
+                raise OperationBusyError(
+                    f"“{self._operation['label']}”正在运行，请先等待或停止再登出。"
+                )
+            detail = self._facade.logout()
+        return {"detail": detail, "login": self.login_status()}
 
     def start_download(self, *, mode: str, target: str,
                        quality: str | None = None,

--- a/src/xdl/frontends/web_static/app.js
+++ b/src/xdl/frontends/web_static/app.js
@@ -83,11 +83,58 @@ async function api(path, options = {}) {
 }
 
 function toast(message, type = "success") {
+  const region = $("#toast-region");
   const node = document.createElement("div");
   node.className = `toast${type === "error" ? " is-error" : ""}`;
   node.textContent = message;
-  $("#toast-region").append(node);
-  window.setTimeout(() => node.remove(), 4200);
+  region.append(node);
+  // top layer 按进入顺序叠放，所以每条提示都重新 show 一次，才能盖住在它之前
+  // 用 showModal() 打开的确认弹窗。不支持 popover 的浏览器退回 z-index。
+  raiseToastRegion();
+  window.setTimeout(() => {
+    node.remove();
+    if (!region.childElementCount) hideToastRegion();
+  }, 4200);
+}
+
+function raiseToastRegion() {
+  hideToastRegion();
+  try {
+    $("#toast-region").showPopover();
+  } catch { /* 浏览器不支持 popover：保持普通定位 */ }
+}
+
+function hideToastRegion() {
+  try {
+    $("#toast-region").hidePopover();
+  } catch { /* 本来就没展示，或不支持 popover */ }
+}
+
+function openLogin() {
+  // 已登录时点这个按钮只可能是想换号。直接开浏览器没用：专用 Profile 里旧账号
+  // 的 token 还在，登录轮询会秒命中并把同一个账号再存一遍。
+  if (state.login?.authenticated) return confirmSwitchAccount();
+  startOperation("/api/operations/login");
+}
+
+function confirmSwitchAccount() {
+  const browserName = state.login?.browser_name || "浏览器";
+  openDialog({
+    title: "换账号登录",
+    sub: `将先清除当前账号的登录凭据，再打开 ${browserName} 让你登录另一个账号。`,
+    lines: [
+      `<div class="line"><i></i><span>删除 Cookie 缓存 <strong>${
+        escapeHtml(state.settings?.cookies_cache_path || "")}</strong></span></div>`,
+      `<div class="line"><i></i><span>删除 ${escapeHtml(browserName)} 专用 Profile <strong>${
+        escapeHtml(state.settings?.chrome_profile_dir || "")}</strong></span></div>`,
+      '<div class="line warn"><i></i><span>浏览器打开后请完成登录；'
+        + '检测到登录态会自动关窗保存。中途可点“优雅停止”放弃。</span></div>',
+    ],
+    safeNote: "只影响 XDL 自己的专用 Profile，不会动你日常使用的浏览器。",
+    confirmText: "清除并重新登录",
+    onConfirm: () => startOperation("/api/operations/login",
+                                    { switch_account: true }),
+  });
 }
 
 function switchView(view) {
@@ -136,10 +183,12 @@ function setDownloadMode(mode) {
 function renderHeader() {
   const loginButton = $("#login-status");
   const loginText = $("#login-status-text");
+  const backend = state.settings?.source_backend || "http";
   // 登录态按浏览器分家，所以状态里必须带上"是哪个浏览器"，否则用户切换浏览器后
   // 只会看到莫名其妙的"尚未登录"。
   const browserName = state.login?.browser_name || "";
   const prefix = browserName ? `${browserName} · ` : "";
+  renderLoginEntry(browserName);
   const other = state.login?.other_browser_authenticated;
   const otherName = other === "edge" ? "Edge" : other === "chrome" ? "Chrome" : "";
   if (state.login?.authenticated) {
@@ -160,12 +209,65 @@ function renderHeader() {
     loginButton.classList.add("is-warning");
     loginButton.title = "点击打开浏览器登录";
   }
-  const backend = state.settings?.source_backend || "http";
   $("#backend-status").textContent =
     backend === "pc" ? "PC 桌面端接口" : backend === "http" ? "HTTP 后端" : "浏览器后端";
   $("#concurrency-status").textContent = `并发 ${state.settings?.max_concurrency ?? 1}`;
   if (state.settings?.default_quality) {
     $("#download-quality").value = state.settings.default_quality;
+  }
+}
+
+// 登录入口的文案跟着登录态走：已登录时点它只可能是想换号，所以直接写"换账号"，
+// 免得用户以为点了会刷新当前账号的凭据。
+function renderLoginEntry(browserName) {
+  const button = $("#login-entry-button");
+  if (!button) return;
+  const authenticated = Boolean(state.login?.authenticated);
+  const name = browserName || "浏览器";
+  button.textContent = authenticated ? "换账号" : `${name} 登录`;
+  button.title = authenticated
+    ? `清除当前登录凭据，再打开 ${name} 登录另一个账号`
+    : `下载前请先在 ${name} 中登录喜马拉雅`;
+  button.classList.toggle("is-warning", !authenticated);
+
+  // 没登录就没什么可登出的，藏起来省得误点
+  const logout = $("#logout-button");
+  if (!logout) return;
+  logout.classList.toggle("is-hidden", !authenticated);
+  logout.title =
+    `清除本地登录凭据（Cookie 缓存与 ${browserName || "浏览器"} 专用 Profile）`;
+}
+
+function confirmLogout() {
+  const browserName = state.login?.browser_name || "浏览器";
+  openDialog({
+    title: "登出当前账号",
+    sub: "将删除本机保存的登录凭据，之后需要重新登录才能下载。",
+    lines: [
+      `<div class="line"><i></i><span>删除 Cookie 缓存 <strong>${
+        escapeHtml(state.settings?.cookies_cache_path || "")}</strong></span></div>`,
+      `<div class="line"><i></i><span>删除 ${escapeHtml(browserName)} 专用 Profile <strong>${
+        escapeHtml(state.settings?.chrome_profile_dir || "")}</strong></span></div>`,
+      `<div class="line"><i></i><span>设备指纹文件 <strong>${
+        escapeHtml(state.settings?.device_info_path || "")
+      }</strong> 不受影响，仍是同一台设备</span></div>`,
+    ],
+    // Profile 必须一起删：只删 Cookie 缓存的话，浏览器里旧账号的会话还在，
+    // 下次登录会被自动登回同一个账号，等于换不了号。
+    safeNote: "只影响 XDL 自己的专用 Profile，不会动你日常使用的浏览器。",
+    confirmText: "确认登出",
+    onConfirm: doLogout,
+  });
+}
+
+async function doLogout() {
+  try {
+    const result = await api("/api/auth/logout", { method: "POST" });
+    state.login = result.login;
+    renderHeader();
+    toast("已登出，登录凭据已清除");
+  } catch (error) {
+    toast(error.message, "error");
   }
 }
 
@@ -394,7 +496,13 @@ function renderOperation() {
   };
   $("#operation-state").textContent = statusLabels[operation.status] || operation.status;
   $("#operation-title").textContent = operation.current_title || operation.label || operationLabels[operation.kind] || "后台操作";
-  $("#operation-message").textContent = operation.message || operationLabels[operation.kind] || "正在准备";
+  // 运行中 message 还是空的，此时最新一条 note 才是有用信息（例如登录在等什么）；
+  // 否则用户在等待期间只会看到一个干巴巴的"登录"。
+  const notes = operation.notes || [];
+  const lastNote = notes.length ? notes[notes.length - 1].message : "";
+  $("#operation-message").textContent = operation.message
+    || (operation.status === "running" ? lastNote : "")
+    || operationLabels[operation.kind] || "正在准备";
   const total = Number(operation.progress_total || 0);
   const done = Number(operation.progress_done || 0);
   const percent = total > 0 ? Math.min(100, Math.floor((done / total) * 100)) : 0;
@@ -671,8 +779,11 @@ async function requeuePicked() {
 function openDialog({ title, sub, lines, confirmText, onConfirm }) {
   const root = $("#dialog-root");
   const previous = document.activeElement;
+  // 必须是原生 <dialog> + showModal()：它在浏览器 top layer 里，普通元素再高
+  // 的 z-index 也压不住；而且 showModal()
+  // 会把文档其余部分置为 inert，普通遮罩即便看得见也点不动。
   root.innerHTML = `
-    <div class="scrim" role="dialog" aria-modal="true" aria-label="${title}">
+    <dialog class="scrim" aria-label="${title}">
       <div class="dialog">
         <h2>${title}</h2>
         ${sub ? `<p class="dialog-sub">${sub}</p>` : ""}
@@ -686,24 +797,26 @@ function openDialog({ title, sub, lines, confirmText, onConfirm }) {
           <button class="button danger" type="button" data-dialog="confirm">${confirmText}</button>
         </div>
       </div>
-    </div>`;
+    </dialog>`;
 
+  const scrim = root.querySelector("dialog");
   const close = () => {
+    if (scrim.open) scrim.close();
     root.innerHTML = "";
-    document.removeEventListener("keydown", onKey, true);
     if (previous?.isConnected) previous.focus();
   };
-  const onKey = (event) => {
-    if (event.key === "Escape") {
-      event.stopPropagation();
-      close();
-    }
-  };
-  document.addEventListener("keydown", onKey, true);
+  scrim.showModal();
+  // Esc 由原生 cancel 事件送来，且只关最上层那个 dialog；自己收尾以便还原焦点
+  scrim.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    close();
+  });
   // 默认焦点落在取消：回车不该等于确认删除
   root.querySelector('[data-dialog="cancel"]').focus();
-  root.addEventListener("click", (event) => {
-    if (event.target.classList.contains("scrim")) return close();
+  // 监听挂在 scrim 上而不是常驻的 root 上：挂 root 会逐次累积，关掉的旧弹窗
+  // 仍会接到新弹窗的点击，把上一次的 onConfirm 又跑一遍。
+  scrim.addEventListener("click", (event) => {
+    if (event.target === scrim) return close();
     const button = event.target.closest("[data-dialog]");
     if (!button) return;
     close();
@@ -907,6 +1020,9 @@ async function saveSettings() {
       body: JSON.stringify(settingsPayload()),
     });
     state.settings = result.settings;
+    // 换后端/换浏览器等于换一套登录体系，登录态必须跟着换；只更新 settings 会让
+    // 头部继续显示上一套凭据的状态（例如切到另一个浏览器后仍写着已登录）。
+    if (result.login) state.login = result.login;
     renderHeader();
     populateSettingsForm();
     toast("设置已保存，运行器已重新加载");
@@ -963,6 +1079,8 @@ document.addEventListener("click", (event) => {
   if (!action) return;
   const actions = {
     "focus-composer": focusComposer,
+    login: openLogin,
+    logout: confirmLogout,
     login: () => startOperation("/api/operations/login"),
     resume: () => startOperation("/api/operations/resume"),
     stop: stopOperation,

--- a/src/xdl/frontends/web_static/app.js
+++ b/src/xdl/frontends/web_static/app.js
@@ -111,30 +111,16 @@ function hideToastRegion() {
 }
 
 function openLogin() {
-  // 已登录时点这个按钮只可能是想换号。直接开浏览器没用：专用 Profile 里旧账号
-  // 的 token 还在，登录轮询会秒命中并把同一个账号再存一遍。
-  if (state.login?.authenticated) return confirmSwitchAccount();
+  // 登录总是先清掉专用 Profile 再开浏览器（见后端 interactive_login），所以
+  // 已登录状态下这里没有"再登录一次"的入口——想换号请先登出。
   startOperation("/api/operations/login");
 }
 
-function confirmSwitchAccount() {
-  const browserName = state.login?.browser_name || "浏览器";
-  openDialog({
-    title: "换账号登录",
-    sub: `将先清除当前账号的登录凭据，再打开 ${browserName} 让你登录另一个账号。`,
-    lines: [
-      `<div class="line"><i></i><span>删除 Cookie 缓存 <strong>${
-        escapeHtml(state.settings?.cookies_cache_path || "")}</strong></span></div>`,
-      `<div class="line"><i></i><span>删除 ${escapeHtml(browserName)} 专用 Profile <strong>${
-        escapeHtml(state.settings?.chrome_profile_dir || "")}</strong></span></div>`,
-      '<div class="line warn"><i></i><span>浏览器打开后请完成登录；'
-        + '检测到登录态会自动关窗保存。中途可点“优雅停止”放弃。</span></div>',
-    ],
-    safeNote: "只影响 XDL 自己的专用 Profile，不会动你日常使用的浏览器。",
-    confirmText: "清除并重新登录",
-    onConfirm: () => startOperation("/api/operations/login",
-                                    { switch_account: true }),
-  });
+// 唯一的登录/登出入口：未登录→登录；已登录→登出确认。想换账号就走
+// 登出（清凭据）→ 再登录（重开浏览器）两步。
+function onLoginEntry() {
+  if (state.login?.authenticated) return confirmLogout();
+  openLogin();
 }
 
 function switchView(view) {
@@ -194,7 +180,7 @@ function renderHeader() {
   if (state.login?.authenticated) {
     loginText.textContent = `${prefix}已保存登录态`;
     loginButton.classList.remove("is-warning");
-    loginButton.title = "点击重新登录";
+    loginButton.title = "点击登出";
   } else if (otherName) {
     loginText.textContent = `${prefix}尚未登录`;
     loginButton.classList.add("is-warning");
@@ -217,25 +203,18 @@ function renderHeader() {
   }
 }
 
-// 登录入口的文案跟着登录态走：已登录时点它只可能是想换号，所以直接写"换账号"，
-// 免得用户以为点了会刷新当前账号的凭据。
+// 登录入口只有一个按钮，跟着登录态走：未登录显示"登录"，已登录显示"登出"。
+// 想换账号 = 登出（清凭据）→ 登录（重开浏览器）两步，没有独立的"换账号"动作。
 function renderLoginEntry(browserName) {
   const button = $("#login-entry-button");
   if (!button) return;
   const authenticated = Boolean(state.login?.authenticated);
   const name = browserName || "浏览器";
-  button.textContent = authenticated ? "换账号" : `${name} 登录`;
+  button.textContent = authenticated ? "登出" : `${name} 登录`;
   button.title = authenticated
-    ? `清除当前登录凭据，再打开 ${name} 登录另一个账号`
+    ? `清除本机保存的登录凭据（Cookie 缓存与 ${name} 专用 Profile）`
     : `下载前请先在 ${name} 中登录喜马拉雅`;
   button.classList.toggle("is-warning", !authenticated);
-
-  // 没登录就没什么可登出的，藏起来省得误点
-  const logout = $("#logout-button");
-  if (!logout) return;
-  logout.classList.toggle("is-hidden", !authenticated);
-  logout.title =
-    `清除本地登录凭据（Cookie 缓存与 ${browserName || "浏览器"} 专用 Profile）`;
 }
 
 function confirmLogout() {
@@ -1080,8 +1059,8 @@ document.addEventListener("click", (event) => {
   const actions = {
     "focus-composer": focusComposer,
     login: openLogin,
+    "login-entry": onLoginEntry,
     logout: confirmLogout,
-    login: () => startOperation("/api/operations/login"),
     resume: () => startOperation("/api/operations/resume"),
     stop: stopOperation,
     "open-downloads": () => openDownloads(),

--- a/src/xdl/frontends/web_static/index.html
+++ b/src/xdl/frontends/web_static/index.html
@@ -46,7 +46,7 @@
       <button class="mobile-brand" type="button" data-view="tasks">XDL</button>
       <div class="topbar-spacer"></div>
       <div class="status-cluster">
-        <button class="status-button" id="login-status" type="button" data-action="login">
+        <button class="status-button" id="login-status" type="button" data-action="login-entry">
           <span class="status-dot" aria-hidden="true"></span>
           <span id="login-status-text">正在检查登录态</span>
         </button>
@@ -66,12 +66,8 @@
           </div>
           <div class="heading-actions">
             <button class="button secondary" id="login-entry-button" type="button"
-                    data-action="login">
+                    data-action="login-entry">
               登录
-            </button>
-            <button class="button secondary is-hidden" id="logout-button" type="button"
-                    data-action="logout">
-              登出
             </button>
             <button class="button secondary" type="button" data-action="open-downloads">
               打开下载目录

--- a/src/xdl/frontends/web_static/index.html
+++ b/src/xdl/frontends/web_static/index.html
@@ -65,6 +65,14 @@
             <p class="page-description">添加你有权访问的专辑或单曲，进度会自动保存。</p>
           </div>
           <div class="heading-actions">
+            <button class="button secondary" id="login-entry-button" type="button"
+                    data-action="login">
+              登录
+            </button>
+            <button class="button secondary is-hidden" id="logout-button" type="button"
+                    data-action="logout">
+              登出
+            </button>
             <button class="button secondary" type="button" data-action="open-downloads">
               打开下载目录
             </button>
@@ -437,7 +445,8 @@
     </form>
   </dialog>
 
-  <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="true"></div>
+  <div class="toast-region" id="toast-region" popover="manual"
+       aria-live="polite" aria-atomic="true"></div>
   <div id="dialog-root"></div>
   <script type="module" src="/app.js"></script>
 </body>

--- a/src/xdl/frontends/web_static/styles.css
+++ b/src/xdl/frontends/web_static/styles.css
@@ -327,6 +327,8 @@ h3 {
 
 .heading-actions {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 9px;
 }
 
@@ -370,6 +372,19 @@ h3 {
   border-color: #9caab5;
   color: var(--ink);
   background: #fbfcfd;
+}
+
+/* 未登录的登录入口：跟顶栏状态点用同一个橙色，两处才像在说同一件事 */
+.button.secondary.is-warning {
+  border-color: #f0b9a8;
+  color: var(--orange);
+  background: var(--orange-soft);
+}
+
+.button.secondary.is-warning:hover:not(:disabled) {
+  border-color: var(--orange);
+  color: var(--orange-hover);
+  background: #ffe6dd;
 }
 
 .button.danger-subtle {
@@ -1032,15 +1047,34 @@ input::placeholder {
 
 /* ---------- 确认弹窗 ---------- */
 
+/* 确认弹窗是原生 <dialog> + showModal()：modal 待在
+   浏览器 top layer 里，普通 z-index 无论多大都盖不过去。下面这些属性是在复位
+   <dialog> 的 UA 默认样式（居中 margin、fit-content 尺寸、边框、背景）。 */
 .scrim {
   position: fixed;
   z-index: 200;
   display: grid;
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  max-height: none;
+  margin: 0;
   padding: 24px;
+  border: 0;
+  color: inherit;
   background: rgba(23, 33, 43, 0.38);
   inset: 0;
   place-items: center;
   animation: scrim-in 130ms ease both;
+}
+
+.scrim:not([open]) {
+  display: none;
+}
+
+/* 遮罩由 .scrim 自身画，原生 backdrop 再叠一层只会更暗 */
+.scrim::backdrop {
+  background: transparent;
 }
 
 @keyframes scrim-in {
@@ -1652,13 +1686,22 @@ input::placeholder {
   line-height: 1.7;
 }
 
+/* 同理：提示要压在 modal 之上，靠 popover 进 top layer。这里同样在复位
+   [popover] 的 UA 默认样式；浏览器不支持时退回 z-index，位置样式不变。 */
 .toast-region {
   position: fixed;
-  right: 22px;
-  bottom: 22px;
   z-index: 100;
   display: grid;
   width: min(360px, calc(100vw - 32px));
+  height: auto;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  overflow: visible;
+  border: 0;
+  color: inherit;
+  background: none;
+  inset: auto 22px 22px auto;
   gap: 9px;
 }
 

--- a/src/xdl/risk.py
+++ b/src/xdl/risk.py
@@ -46,6 +46,7 @@ class RiskEventRecorder:
                 request_index: int | None = None,
                 started_at: str | None = None,
                 authenticated: bool | None = None,
+                backend: str | None = None,
                 device_fingerprint_reset: bool | None = None) -> None:
         event = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -56,6 +57,10 @@ class RiskEventRecorder:
             "msg": msg,
             "in_flight": int(in_flight),
         }
+        # 各后端打的是完全不同的接口，风控额度也各算各的。不标后端，日志混在
+        # 一起就再也分不出"这条限流是 APK 的还是 PC 的"。
+        if backend is not None:
+            event["backend"] = str(backend)
         if session_id is not None:
             event["session_id"] = str(session_id)
         if request_index is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -213,7 +213,7 @@ def test_main_help_focuses_on_normal_user_flow(capsys):
 
     assert exc.value.code == 0
     output = capsys.readouterr().out
-    assert "{web,login,track,album,resume,gen-sign,risk-report}" in output
+    assert "{web,login,logout,track,album,resume,gen-sign,risk-report}" in output
     assert "启动本地 WebUI" in output
     assert "extract-device" not in output
     assert "refresh-cookies" not in output

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -17,7 +17,8 @@ class FakeSource:
         self.track = track
         self.error = error
 
-    def interactive_login(self):
+    def interactive_login(self, *, reset=False, cancel=None, notify=None):
+        self.login_wait = {"reset": reset, "cancel": cancel, "notify": notify}
         return "/tmp/xdl-profile"
 
     async def open(self):

--- a/tests/test_identity_layout.py
+++ b/tests/test_identity_layout.py
@@ -233,3 +233,51 @@ def test_login_status_ignores_other_browser_for_custom_path(home):
         Settings(browser="edge", cookies_cache_path=str(home / "mine.json")))
 
     assert status["other_browser_authenticated"] is None
+
+
+# ---- chrome 后端的登录态判定（Profile Cookie DB，而非缓存文件） ----
+
+def _write_profile_token(profile_dir) -> None:
+    """在专用 Profile 的 Cookie DB 里写入一条登录 token（模拟已登录）。"""
+    import sqlite3
+    db_dir = profile_dir / "Default" / "Network"
+    db_dir.mkdir(parents=True)
+    with sqlite3.connect(db_dir / "Cookies") as conn:
+        conn.execute(
+            "CREATE TABLE cookies (name TEXT, encrypted_value BLOB, value TEXT)")
+        conn.execute("INSERT INTO cookies VALUES (?, ?, ?)",
+                     ("1&_token", b"encrypted-token", ""))
+
+
+def test_chrome_backend_reads_login_state_from_profile(home):
+    """chrome 后端不写 Cookie 缓存文件；登录态必须看专用 Profile 的 Cookie DB。
+
+    否则前端恒报未登录：登出入口被藏掉，"换账号"走成普通登录秒命中旧 token。
+    """
+    profile = home / "chrome-profile"
+    _write_profile_token(profile)
+
+    status = login_cache_status(Settings(source_backend="chrome"))
+
+    assert status["authenticated"] is True
+
+
+def test_chrome_backend_without_profile_token_reports_logged_out(home):
+    """chrome 后端 + 空 Profile：即使缓存文件里有 token 也不算登录。
+
+    缓存文件对 chrome 后端没有约束力——下载走 Profile，不走缓存。
+    """
+    _write_login_cookies(home / "chrome-cookies.json")
+
+    status = login_cache_status(Settings(source_backend="chrome"))
+
+    assert status["authenticated"] is False
+
+
+def test_http_backend_still_reads_cache_file(home):
+    """http/pc 后端维持原行为：登录态看 Cookie 缓存文件。"""
+    _write_login_cookies(home / "chrome-cookies.json")
+
+    status = login_cache_status(Settings(source_backend="http"))
+
+    assert status["authenticated"] is True

--- a/tests/test_risk_control.py
+++ b/tests/test_risk_control.py
@@ -759,6 +759,18 @@ def test_profile_wipe_refuses_paths_that_are_not_browser_profiles(tmp_path):
     assert wipe_browser_profile(str(tmp_path / "missing")) is False
 
 
+def test_profile_wipe_refuses_while_browser_running(tmp_path, monkeypatch):
+    """守卫必须在底层函数里：绕过 logout 直接调 wipe 也不能删掉在用的 Profile。"""
+    profile = tmp_path / "profile"
+    (profile / "Default").mkdir(parents=True)
+    monkeypatch.setattr("xdl.adapters.source_chrome._port_alive",
+                        lambda _port: True)
+
+    with pytest.raises(ConfigError, match="仍被占用"):
+        wipe_browser_profile(str(profile), port=9222)
+    assert profile.exists()
+
+
 class _RiskSource:
     def __init__(self):
         self.calls = []

--- a/tests/test_risk_control.py
+++ b/tests/test_risk_control.py
@@ -3,16 +3,19 @@ import asyncio
 import builtins
 import json
 import sqlite3
+import time
 
 import pytest
 
 from xdl.adapters.source_chrome import (ChromeSource, _has_login_cookie,
                                         _is_captcha_url, _parse_base_info_payload,
-                                        _is_device_fingerprint_cookie)
+                                        _is_device_fingerprint_cookie,
+                                        wipe_browser_profile)
 from xdl.application.usecases import (DownloadTrackUseCase, DownloadAlbumUseCase,
                                       RetryPolicy)
 from xdl.domain import Album, AlbumTrack, Quality
-from xdl.errors import ApiError, AuthError, RiskControlError
+from xdl.errors import (ApiError, AuthError, CancelledByUser, ConfigError,
+                        RiskControlError)
 from xdl.frontends.cli import _print_album_result
 from xdl.risk import RiskEventRecorder, summarize_risk_events
 from xdl.settings import Settings
@@ -74,6 +77,31 @@ def _patch_login_playwright(monkeypatch, cookies, pages=()):
 
     monkeypatch.setattr(sync_api, "sync_playwright", lambda: _Manager())
     return browser
+
+
+class _LiveProcess:
+    """仍在运行的浏览器进程替身：poll() 返回 None 表示没退出。"""
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+
+def _await_login(source, *, cancel=None, expired=False):
+    """按新签名调用轮询等待；expired=True 表示 deadline 已过（立即判超时）。"""
+    return source._await_interactive_login(
+        _LiveProcess(), cancel=cancel, announce=lambda _msg: None,
+        deadline=time.monotonic() + (-1 if expired else 60),
+        poll_interval=0,
+    )
 
 
 @pytest.mark.parametrize("ret,msg", [
@@ -484,8 +512,9 @@ def test_login_verification_rejects_dom_only_state(monkeypatch):
     browser = _patch_login_playwright(monkeypatch, [], pages=[_Page()])
     source = ChromeSource(_Decoder(), "chrome", "profile")
 
-    assert source._verify_interactive_login() is False
+    assert _await_login(source, expired=True) is False
     assert browser.closed is False
+    assert browser.root_cdp_commands == []
 
 
 def test_login_verification_never_resets_profile_state(monkeypatch):
@@ -508,7 +537,7 @@ def test_login_verification_never_resets_profile_state(monkeypatch):
     monkeypatch.setattr(source, "_reset_device_cookies_sync",
                         lambda _context: reset_calls.append(True))
 
-    assert source._verify_interactive_login() is True
+    assert _await_login(source) is True
     assert browser.root_cdp_commands == ["Browser.close"]
     assert browser.closed is False
     assert reset_calls == []
@@ -522,54 +551,174 @@ def test_device_fingerprint_reset_is_disabled_by_default():
     assert Settings().reset_device_fingerprint is False
 
 
-def test_interactive_login_reprompts_until_verified(tmp_path, monkeypatch):
+def _stub_login_launch(monkeypatch, launched=None):
+    """让 interactive_login 走到等待阶段：假进程 + 调试端口先关后开。"""
+    port_states = iter([False, True])
+
+    def fake_popen(args, **_kwargs):
+        if launched is not None:
+            launched["args"] = args
+        return _LiveProcess()
+
+    monkeypatch.setattr("xdl.adapters.source_chrome.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("xdl.adapters.source_chrome._port_alive",
+                        lambda _port: next(port_states))
+    monkeypatch.setattr("xdl.adapters.source_chrome.time.sleep", lambda _s: None)
+
+
+def _forbid_stdin(monkeypatch):
+    """登录路径一旦回头读 stdin 就直接失败。
+
+    这是回归闸门：WebUI 的服务进程没有 tty，`input()` 会立刻抛 EOFError，
+    finally 随之杀掉浏览器——用户看到的就是"窗口一闪就关"。
+    """
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("登录流程不得读取 stdin")
+
+    monkeypatch.setattr(builtins, "input", _boom)
+
+
+def test_interactive_login_polls_until_token_appears(tmp_path, monkeypatch):
+    """轮询 CDP 直到出现登录 token，全程不碰终端。"""
+    import playwright.sync_api as sync_api
+
     chrome = tmp_path / "chrome.exe"
     chrome.write_bytes(b"")
     source = ChromeSource(_Decoder(), str(chrome), str(tmp_path / "profile"))
     launched = {}
-    prompts = []
-    verifications = iter([False, True])
-    port_states = iter([False, True])
+    polls = {"count": 0}
+    commands = []
 
-    class FakeProcess:
-        def terminate(self):
-            pass
+    class _Context:
+        def cookies(self, *_urls):
+            polls["count"] += 1
+            if polls["count"] < 3:      # 前两轮用户还没登录完
+                return []
+            return [{"name": "1&_token", "value": "present",
+                     "domain": ".ximalaya.com", "path": "/"}]
 
-        def wait(self, timeout=None):
-            return 0
+    class _Browser:
+        contexts = [_Context()]
 
-        def kill(self):
-            pass
+        def new_browser_cdp_session(self):
+            class _RootSession:
+                def send(self, method):
+                    commands.append(method)
+            return _RootSession()
 
-    def fake_popen(args, **kwargs):
-        launched["args"] = args
-        return FakeProcess()
+    class _Manager:
+        def __enter__(self):
+            class _Playwright:
+                class chromium:
+                    @staticmethod
+                    def connect_over_cdp(_url):
+                        return _Browser()
+            return _Playwright()
 
-    def fake_input(prompt):
-        prompts.append(prompt)
-        return ""
+        def __exit__(self, *_args):
+            return False
 
-    monkeypatch.setattr("xdl.adapters.source_chrome.subprocess.Popen", fake_popen)
-    monkeypatch.setattr(
-        "xdl.adapters.source_chrome._port_alive",
-        lambda _port: next(port_states),
-    )
-    monkeypatch.setattr(builtins, "input", fake_input)
-    monkeypatch.setattr(
-        source, "_verify_interactive_login",
-        lambda: next(verifications), raising=False,
-    )
+    monkeypatch.setattr(sync_api, "sync_playwright", lambda: _Manager())
+    _stub_login_launch(monkeypatch, launched)
+    _forbid_stdin(monkeypatch)
     monkeypatch.setattr(
         "xdl.adapters.source_chrome._has_persisted_login_cookie",
         lambda _profile_dir: True, raising=False,
     )
 
-    assert source.interactive_login() == str(tmp_path / "profile")
-    assert len(prompts) == 2
+    path = source.interactive_login(wait_timeout=60)
+
+    assert path == str(tmp_path / "profile")
+    assert polls["count"] == 3            # 轮询到第三轮才拿到 token
+    assert commands == ["Browser.close"]  # 成功后走 Chrome 自身的正常退出
     assert "--remote-debugging-port=9222" in launched["args"]
-    assert _has_login_cookie([
-        {"name": "1&_token", "value": ""},
-    ]) is False
+
+
+def test_interactive_login_reset_wipes_profile_before_waiting(tmp_path, monkeypatch):
+    """换账号：必须先清 Profile，再等新登录。
+
+    不清的话，Profile 里旧账号的 token 会让第一轮轮询立刻命中——浏览器一闪即
+    关，存下来的还是同一个账号，用户就"换不了号"。
+    """
+    chrome = tmp_path / "chrome.exe"
+    chrome.write_bytes(b"")
+    profile = tmp_path / "profile"
+    (profile / "Default").mkdir(parents=True)
+    (profile / "Local State").write_text("{}", encoding="utf-8")
+    source = ChromeSource(_Decoder(), str(chrome), str(profile))
+    wiped_before_launch = {}
+
+    _patch_login_playwright(monkeypatch, [])
+    _forbid_stdin(monkeypatch)
+    port_states = iter([False, False, True])
+    monkeypatch.setattr("xdl.adapters.source_chrome._port_alive",
+                        lambda _port: next(port_states))
+    monkeypatch.setattr("xdl.adapters.source_chrome.time.sleep", lambda _s: None)
+
+    def fake_popen(_args, **_kwargs):
+        # 浏览器启动时 Profile 必须已经是空的（目录会被重新创建，看内容）
+        wiped_before_launch["empty"] = not any(profile.iterdir())
+        return _LiveProcess()
+
+    monkeypatch.setattr("xdl.adapters.source_chrome.subprocess.Popen", fake_popen)
+
+    # 清完 Profile 后没人登录 → 应超时报错，而不是"秒成功"
+    with pytest.raises(AuthError, match="等待登录超时"):
+        source.interactive_login(reset=True, wait_timeout=0)
+
+    assert wiped_before_launch["empty"] is True
+    assert not (profile / "Local State").exists()
+
+
+def test_interactive_login_without_reset_warns_about_existing_session(tmp_path,
+                                                                     monkeypatch):
+    """不换号时至少要说清"复用了已有登录态"，不能让用户以为登了新账号。"""
+    chrome = tmp_path / "chrome.exe"
+    chrome.write_bytes(b"")
+    profile = tmp_path / "profile"
+    (profile / "Default").mkdir(parents=True)
+    source = ChromeSource(_Decoder(), str(chrome), str(profile))
+    notes = []
+
+    _patch_login_playwright(monkeypatch, [])
+    _stub_login_launch(monkeypatch)
+    _forbid_stdin(monkeypatch)
+    monkeypatch.setattr(
+        "xdl.adapters.source_chrome._has_persisted_login_cookie",
+        lambda _profile_dir: True, raising=False,
+    )
+
+    with pytest.raises(AuthError, match="等待登录超时"):
+        source.interactive_login(notify=notes.append, wait_timeout=0)
+
+    assert any("已有登录态" in note for note in notes)
+    assert profile.exists()      # 没要求换号就绝不能删 Profile
+
+
+def test_interactive_login_stops_when_cancelled(tmp_path, monkeypatch):
+    """WebUI 的"优雅停止"要能中断等待，而不是干等到超时。"""
+    chrome = tmp_path / "chrome.exe"
+    chrome.write_bytes(b"")
+    source = ChromeSource(_Decoder(), str(chrome), str(tmp_path / "profile"))
+    _patch_login_playwright(monkeypatch, [])
+    _stub_login_launch(monkeypatch)
+    _forbid_stdin(monkeypatch)
+
+    with pytest.raises(CancelledByUser):
+        source.interactive_login(cancel=lambda: True, wait_timeout=60)
+
+
+def test_interactive_login_times_out_without_login(tmp_path, monkeypatch):
+    """等不到登录要报超时，而不是悄悄返回一个"成功"的 Profile 路径。"""
+    chrome = tmp_path / "chrome.exe"
+    chrome.write_bytes(b"")
+    source = ChromeSource(_Decoder(), str(chrome), str(tmp_path / "profile"))
+    _patch_login_playwright(monkeypatch, [])
+    _stub_login_launch(monkeypatch)
+    _forbid_stdin(monkeypatch)
+
+    with pytest.raises(AuthError, match="等待登录超时"):
+        source.interactive_login(wait_timeout=0)
 
 
 def test_interactive_login_rejects_unpersisted_token(tmp_path, monkeypatch):
@@ -577,24 +726,10 @@ def test_interactive_login_rejects_unpersisted_token(tmp_path, monkeypatch):
     chrome.write_bytes(b"")
     source = ChromeSource(_Decoder(), str(chrome), str(tmp_path / "profile"))
 
-    class _Process:
-        def terminate(self):
-            pass
-
-        def wait(self, timeout=None):
-            return 0
-
-        def kill(self):
-            pass
-
-    port_states = iter([False, True])
-    monkeypatch.setattr("xdl.adapters.source_chrome.subprocess.Popen",
-                        lambda *a, **kw: _Process())
-    monkeypatch.setattr("xdl.adapters.source_chrome._port_alive",
-                        lambda _port: next(port_states))
-    monkeypatch.setattr(builtins, "input", lambda _prompt: "")
-    monkeypatch.setattr(source, "_verify_interactive_login",
-                        lambda: True, raising=False)
+    _stub_login_launch(monkeypatch)
+    _forbid_stdin(monkeypatch)
+    monkeypatch.setattr(source, "_await_interactive_login",
+                        lambda *a, **kw: True, raising=False)
     monkeypatch.setattr(
         "xdl.adapters.source_chrome._has_persisted_login_cookie",
         lambda _profile_dir: False, raising=False,
@@ -602,6 +737,46 @@ def test_interactive_login_rejects_unpersisted_token(tmp_path, monkeypatch):
 
     with pytest.raises(AuthError, match="未持久化"):
         source.interactive_login()
+
+
+def test_logout_wipes_dedicated_profile(tmp_path, monkeypatch):
+    """登出必须删 Profile：只清 Cookie 缓存的话浏览器会自动登回旧账号。"""
+    profile = tmp_path / "profile"
+    (profile / "Default").mkdir(parents=True)
+    (profile / "Local State").write_text("{}", encoding="utf-8")
+    source = ChromeSource(_Decoder(), "chrome", str(profile))
+    monkeypatch.setattr("xdl.adapters.source_chrome._port_alive",
+                        lambda _port: False)
+
+    result = source.logout()
+
+    assert result["profile_removed"] is True
+    assert not profile.exists()
+
+
+def test_logout_refuses_when_browser_still_running(tmp_path, monkeypatch):
+    """浏览器还开着就删 Profile，退出时会把旧登录态重新写回来。"""
+    profile = tmp_path / "profile"
+    (profile / "Default").mkdir(parents=True)
+    source = ChromeSource(_Decoder(), "chrome", str(profile))
+    monkeypatch.setattr("xdl.adapters.source_chrome._port_alive",
+                        lambda _port: True)
+
+    with pytest.raises(ConfigError, match="仍被占用"):
+        source.logout()
+    assert profile.exists()
+
+
+def test_profile_wipe_refuses_paths_that_are_not_browser_profiles(tmp_path):
+    """闸门：chrome_profile_dir 被误配时，绝不能递归删掉用户的真实目录。"""
+    victim = tmp_path / "documents"
+    (victim / "important").mkdir(parents=True)
+
+    with pytest.raises(ConfigError, match="不是浏览器专用 Profile"):
+        wipe_browser_profile(str(victim))
+    assert (victim / "important").exists()
+    # 目录不存在时是无操作，不是报错
+    assert wipe_browser_profile(str(tmp_path / "missing")) is False
 
 
 class _RiskSource:

--- a/tests/test_risk_control.py
+++ b/tests/test_risk_control.py
@@ -552,8 +552,12 @@ def test_device_fingerprint_reset_is_disabled_by_default():
 
 
 def _stub_login_launch(monkeypatch, launched=None):
-    """让 interactive_login 走到等待阶段：假进程 + 调试端口先关后开。"""
-    port_states = iter([False, True])
+    """让 interactive_login 走到等待阶段：假进程 + 调试端口先关后开。
+
+    端口探测序列：登录前的占用检查 → logout 清 Profile 前的占用检查 →
+    启动浏览器后的就绪轮询（第二次才就绪）。
+    """
+    port_states = iter([False, False, False, True])
 
     def fake_popen(args, **_kwargs):
         if launched is not None:
@@ -634,11 +638,12 @@ def test_interactive_login_polls_until_token_appears(tmp_path, monkeypatch):
     assert "--remote-debugging-port=9222" in launched["args"]
 
 
-def test_interactive_login_reset_wipes_profile_before_waiting(tmp_path, monkeypatch):
-    """换账号：必须先清 Profile，再等新登录。
+def test_interactive_login_wipes_profile_before_waiting(tmp_path, monkeypatch):
+    """登录总是先清 Profile 再等新登录——不复用旧登录态。
 
     不清的话，Profile 里旧账号的 token 会让第一轮轮询立刻命中——浏览器一闪即
-    关，存下来的还是同一个账号，用户就"换不了号"。
+    关，存下来的还是同一个账号，用户想换号就换不掉。"换账号"因此不是独立分支：
+    先登出再登录即可。
     """
     chrome = tmp_path / "chrome.exe"
     chrome.write_bytes(b"")
@@ -650,7 +655,7 @@ def test_interactive_login_reset_wipes_profile_before_waiting(tmp_path, monkeypa
 
     _patch_login_playwright(monkeypatch, [])
     _forbid_stdin(monkeypatch)
-    port_states = iter([False, False, True])
+    port_states = iter([False, False, False, True])
     monkeypatch.setattr("xdl.adapters.source_chrome._port_alive",
                         lambda _port: next(port_states))
     monkeypatch.setattr("xdl.adapters.source_chrome.time.sleep", lambda _s: None)
@@ -664,35 +669,10 @@ def test_interactive_login_reset_wipes_profile_before_waiting(tmp_path, monkeypa
 
     # 清完 Profile 后没人登录 → 应超时报错，而不是"秒成功"
     with pytest.raises(AuthError, match="等待登录超时"):
-        source.interactive_login(reset=True, wait_timeout=0)
+        source.interactive_login(wait_timeout=0)
 
     assert wiped_before_launch["empty"] is True
     assert not (profile / "Local State").exists()
-
-
-def test_interactive_login_without_reset_warns_about_existing_session(tmp_path,
-                                                                     monkeypatch):
-    """不换号时至少要说清"复用了已有登录态"，不能让用户以为登了新账号。"""
-    chrome = tmp_path / "chrome.exe"
-    chrome.write_bytes(b"")
-    profile = tmp_path / "profile"
-    (profile / "Default").mkdir(parents=True)
-    source = ChromeSource(_Decoder(), str(chrome), str(profile))
-    notes = []
-
-    _patch_login_playwright(monkeypatch, [])
-    _stub_login_launch(monkeypatch)
-    _forbid_stdin(monkeypatch)
-    monkeypatch.setattr(
-        "xdl.adapters.source_chrome._has_persisted_login_cookie",
-        lambda _profile_dir: True, raising=False,
-    )
-
-    with pytest.raises(AuthError, match="等待登录超时"):
-        source.interactive_login(notify=notes.append, wait_timeout=0)
-
-    assert any("已有登录态" in note for note in notes)
-    assert profile.exists()      # 没要求换号就绝不能删 Profile
 
 
 def test_interactive_login_stops_when_cancelled(tmp_path, monkeypatch):

--- a/tests/test_source_pc.py
+++ b/tests/test_source_pc.py
@@ -419,3 +419,42 @@ def test_http_get_raises_network_error_when_both_fail(monkeypatch):
     with pytest.raises(NetworkError) as exc:
         src._http_get("https://pc.ximalaya.com/x", {}, {})
     assert exc.value.retryable is True
+
+
+def test_risk_events_are_actually_written_and_tagged(tmp_path):
+    """PC 后端必须真的把观测落盘，并标上 backend。
+
+    回归钉子：`_record` 曾经传 `message=`，而 `RiskEventRecorder.record()` 的参数
+    叫 `msg` —— 每次调用都抛 TypeError，又被 `except Exception: pass` 吞掉，于是
+    PC 后端从头到尾一条事件都没记过，风控日志里全是 HTTP 时期的数据。参数名写错
+    是静默的，只有断言"文件里确实出现了这条事件"才拦得住。
+    """
+    from xdl.risk import RiskEventRecorder
+
+    log = tmp_path / "risk.jsonl"
+    src = PcHttpSource(impersonate="", risk_recorder=RiskEventRecorder(str(log)))
+    src._authenticated = True
+
+    src._record("123", 0.0, "success", None, None, 1)
+    src._record("124", 0.0, "risk_control", 1001, "系统繁忙，请稍后再试!", 2)
+    src._record_album("77", "api_error", 500, "boom")
+
+    rows = [json.loads(line) for line in log.read_text("utf-8").splitlines()]
+    assert [r["track_id"] for r in rows] == ["123", "124", "album:77"]
+    assert [r["outcome"] for r in rows] == ["success", "risk_control", "api_error"]
+    assert {r["backend"] for r in rows} == {"pc"}
+    assert rows[1]["ret"] == 1001
+    assert rows[1]["msg"] == "系统繁忙，请稍后再试!"
+    assert rows[0]["authenticated"] is True
+    assert len({r["session_id"] for r in rows}) == 1
+
+
+def test_record_surfaces_signature_errors_instead_of_swallowing(tmp_path):
+    """观测层只允许吞写盘失败；调用约定不匹配必须炸出来。"""
+    class PickyRecorder:
+        def record(self, **kwargs):
+            raise TypeError("record() got an unexpected keyword argument")
+
+    src = PcHttpSource(impersonate="", risk_recorder=PickyRecorder())
+    with pytest.raises(TypeError):
+        src._record("123", 0.0, "success", None, None, 1)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -101,6 +101,15 @@ class FakeRuntime:
         self.calls.append(("settings", changes))
         return changes
 
+    def login_status(self):
+        self.calls.append(("login_status",))
+        return {"authenticated": False, "browser_name": "Chrome"}
+
+    def logout(self):
+        self.calls.append(("logout",))
+        return {"detail": {"profile_removed": True},
+                "login": {"authenticated": False, "browser_name": "Chrome"}}
+
     def open_downloads(self, task_id=None):
         return {"path": "/tmp/downloads", "task_id": task_id}
 
@@ -137,6 +146,8 @@ def test_webui_static_shell_is_served():
     assert 'name="experiment_require_identity_change"' in page.text
     assert 'name="experiment_rebirth_rounds"' in page.text
     assert 'id="task-pagination"' in page.text
+    assert 'id="login-entry-button"' in page.text
+    assert 'id="logout-button"' in page.text
     assert "window.setInterval(refreshRuntime, 850)" not in script.text
     assert "document.hidden" in script.text
     assert "javascript" in script.headers["content-type"]
@@ -226,6 +237,20 @@ def test_web_api_accepts_pc_source_backend():
 
     assert response.status_code == 200
     assert response.json()["settings"]["source_backend"] == "pc"
+    # 换后端/换浏览器要顺带回传新登录态，否则前端会继续显示上一套凭据的状态
+    assert response.json()["login"] == {"authenticated": False,
+                                        "browser_name": "Chrome"}
+
+
+def test_web_api_logout_clears_credentials_for_any_backend():
+    runtime = FakeRuntime()
+    with TestClient(create_app(runtime)) as client:
+        response = client.post("/api/auth/logout")
+
+    assert response.status_code == 200
+    assert response.json()["login"]["authenticated"] is False
+    assert response.json()["detail"]["profile_removed"] is True
+    assert ("logout",) in runtime.calls
 
 
 def test_web_api_rejects_unknown_source_backend():

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -147,7 +147,8 @@ def test_webui_static_shell_is_served():
     assert 'name="experiment_rebirth_rounds"' in page.text
     assert 'id="task-pagination"' in page.text
     assert 'id="login-entry-button"' in page.text
-    assert 'id="logout-button"' in page.text
+    # 登录/登出是同一个按钮（按登录态切换文案），不再有独立登出按钮
+    assert 'id="logout-button"' not in page.text
     assert "window.setInterval(refreshRuntime, 850)" not in script.text
     assert "document.hidden" in script.text
     assert "javascript" in script.headers["content-type"]

--- a/tests/test_web_runtime.py
+++ b/tests/test_web_runtime.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import threading
+from dataclasses import replace
 
 import pytest
 
@@ -118,8 +119,16 @@ class FakeFacade:
     def resume(self, reporter=None, cancel=None):
         return [AlbumResult("测试专辑", skipped=["a.mp3"])]
 
-    def login(self):
+    def login(self, *, reset=False, cancel=None, notify=None):
+        self.login_wait = {"reset": reset, "cancel": cancel, "notify": notify}
+        if notify is not None:
+            notify("已打开浏览器，请完成登录。")
         return "/tmp/profile"
+
+    def logout(self):
+        self.logged_out = True
+        return {"authenticated": False, "cookie_cache_removed": True,
+                "profile_removed": True}
 
     def list_formats(self, target):
         return {"track_id": target, "title": "测试单曲", "formats": []}
@@ -164,6 +173,74 @@ def test_runtime_download_and_task_snapshots(tmp_path):
         "offset": 0, "limit": 100, "total": 2,
         "has_previous": False, "has_next": False,
     }
+
+
+def test_runtime_login_is_cancellable_and_reports_progress(tmp_path):
+    """登录等待必须可中断、且进度要能到 WebUI。
+
+    WebUI 没有终端，等待期间用户唯一能看到的就是 note；不可中断的话，用户想
+    放弃登录只能等超时。
+    """
+    facade = FakeFacade()
+    runtime = WebRuntime(_settings(tmp_path), facade=facade,
+                         persist_settings=False)
+
+    started = runtime.start_login()
+    finished = runtime.wait()
+
+    assert started["cancellable"] is True
+    assert finished["status"] == "succeeded"
+    assert facade.login_wait["cancel"] is not None
+    assert facade.login_wait["notify"] is not None
+    assert "已打开浏览器，请完成登录。" in [
+        note["message"] for note in finished["notes"]
+    ]
+
+
+def test_runtime_switch_account_login_requests_reset(tmp_path):
+    """换账号必须带 reset：否则 Profile 里的旧 token 会让登录秒判成功。"""
+    facade = FakeFacade()
+    runtime = WebRuntime(_settings(tmp_path), facade=facade,
+                         persist_settings=False)
+
+    started = runtime.start_login(switch_account=True)
+    finished = runtime.wait()
+
+    assert started["label"] == "换账号登录"
+    assert facade.login_wait["reset"] is True
+    assert finished["result"]["switch_account"] is True
+
+
+def test_runtime_plain_login_does_not_reset(tmp_path):
+    facade = FakeFacade()
+    runtime = WebRuntime(_settings(tmp_path), facade=facade,
+                         persist_settings=False)
+
+    runtime.start_login()
+    runtime.wait()
+
+    assert facade.login_wait["reset"] is False
+
+
+def test_runtime_logout_returns_refreshed_login_status(tmp_path):
+    facade = FakeFacade()
+    runtime = WebRuntime(replace(_settings(tmp_path), source_backend="pc"),
+                         facade=facade, persist_settings=False)
+
+    result = runtime.logout()
+
+    assert facade.logged_out is True
+    assert result["detail"]["profile_removed"] is True
+    assert result["login"]["authenticated"] is False
+
+
+def test_runtime_refuses_logout_while_operation_runs(tmp_path):
+    runtime = WebRuntime(_settings(tmp_path), facade=FakeFacade(),
+                         persist_settings=False)
+    runtime._operation = {"status": "running", "label": "恢复全部"}
+
+    with pytest.raises(OperationBusyError, match="正在运行"):
+        runtime.logout()
 
 
 def test_runtime_filters_and_pages_task_snapshots(tmp_path):


### PR DESCRIPTION
## 问题

三个独立的既有缺陷，都会让用户卡在“登录”这一步或者拿不到诊断数据。

### 1. WebUI 点登录，浏览器一闪就关

登录流程在服务线程里调 `input()` 等用户确认。WebUI 进程没有 tty，直接抛
`EOFError`，浏览器随即被关掉。操作记录里只留下一句 `EOF when reading a line`。

### 2. 无法登出，也换不了账号

没有登出入口。而且专用 Profile 里只要还留着旧账号的 token，再点登录会“秒成功”
——实际上是把同一个账号又存了一遍，用户以为换号了其实没有。

### 3. PC 后端的风控观测从头到尾一条都没落盘

```python
self._risk_recorder.record(..., message=str(msg or ""))   # record() 的参数叫 msg
except Exception:                                          # TypeError 在这里被吞掉
    pass
```

`RiskEventRecorder.record()` 是纯关键字参数且没有 `**kwargs`，所以 `PcHttpSource`
每次记录都抛 `TypeError`，又被 `except Exception: pass` 静默吃掉。结果是 PC 后端
跑了多少、什么时候被限流，本地日志里一片空白，`xdl risk-report` 的数据全部来自
其它后端。

## 改动

**登录**改成 CDP 轮询检测登录 Cookie，CLI 与 WebUI 共用一条路径，可取消、可超时、
有逐步提示；换账号（`reset=True`）先擦 Profile 再开浏览器，复用已有登录态时明确
提示而不是静默放行。

**登出**新增 `POST /api/auth/logout` 与各音源的 `logout()`：Cookie 缓存、专用
Profile、内存副本三处一起清——只清一处，下次 `open()` 会被旧账号顶回来。
`wipe_browser_profile()` 带守卫：拒绝根目录级路径、要求目录含 `Local State` 或
`Default` 标记、浏览器仍在运行时拒绝删。

**设置改动后的登录态**：换浏览器等于换一套凭据，`PUT /api/settings` 现在返回
`{settings, login}`，头部与登录入口跟着刷新。

**观测**：修正参数名，并把 catch 收窄到 `OSError`——观测层只该吞写盘失败，调用
约定不匹配必须炸出来而不是装作没事。事件新增 `backend` 字段（`pc`/`http`/`chrome`），
各后端风控额度各算各的，不标后端就分不出某条限流属于谁。旧记录无该字段，向后兼容。

另外单独一个提交修了 master 上恒定失败的
`test_album_risk_poll_recovers_and_continues`：`initial_wait<=0` 时首次探针其实
一秒都没等，却把探针自身耗时算进了 `risk_wait_seconds`。

## 影响面

- **破坏性**：`PUT /api/settings` 返回值由 settings 变为 `{settings, login}`
- 新增 `POST /api/auth/logout`
- `Facade.login()` 增加 `reset`/`cancel`/`notify` 三个关键字参数（均有默认值）
- 风控日志新增可选 `backend` 字段，旧记录仍可解析

## 验证

`342 passed`，逐提交均为绿。新增的回归钉子里有一条专门盯参数名：

```python
def test_risk_events_are_actually_written_and_tagged(tmp_path):
    """参数名写错是静默的，只有断言“文件里确实出现了这条事件”才拦得住。"""
```

另一条断言签名不匹配时必须抛出而不是被吞。改动前这两条会失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
